### PR TITLE
fix(parser): parse implicit first request

### DIFF
--- a/http-example-files/implicit-first-request.http
+++ b/http-example-files/implicit-first-request.http
@@ -1,0 +1,16 @@
+@MY_VAR = 123
+# @kulala-curl--insecure
+
+< {%
+  request.variables.set("users", [
+    { name: "Alice" },
+    { name: "Bob" },
+  ])
+%}
+
+GET https://httpbin.org/get?user={{users[*].name}} HTTP/1.1
+Content-Type: application/json
+
+### FOO
+
+GET https://httpbin.org/get?var={{MY_VAR}} HTTP/1.1

--- a/packages/core/src/lib/parser/at-variables.ts
+++ b/packages/core/src/lib/parser/at-variables.ts
@@ -3,6 +3,9 @@
  * See https://www.jetbrains.com/help/idea/http-client-variables.html
  */
 
+import { isRequestLine } from "./request";
+import { isPreRequestScriptLine } from "./script";
+
 const AT_VAR_LINE = /^@([A-Za-z0-9_.-]+)\s*=\s*(.*)$/;
 
 /**
@@ -24,7 +27,7 @@ export function parseAtVariableLine(
 }
 
 /**
- * Collect @ variables from lines before the first ### block marker.
+ * Collect @ variables from lines before the first request or ### block marker.
  */
 export function extractFileHeaderAtVariables(
   content: string,
@@ -32,7 +35,12 @@ export function extractFileHeaderAtVariables(
   const out: Record<string, string> = {};
   for (const line of content.split("\n")) {
     const t = line.trim();
-    if (t.startsWith("###")) break;
+    if (
+      t.startsWith("###") ||
+      isRequestLine(line) ||
+      isPreRequestScriptLine(line)
+    )
+      break;
     if (!t || t.startsWith("#")) continue;
     const p = parseAtVariableLine(line);
     if (p) out[p.name] = p.value;

--- a/packages/core/src/lib/parser/operator.ts
+++ b/packages/core/src/lib/parser/operator.ts
@@ -1,4 +1,6 @@
 import { isKulalaCurlPassthroughOperator } from "../curl/passthrough";
+import { isRequestLine } from "./request";
+import { isPreRequestScriptLine } from "./script";
 import type { KulalaError } from "./types/error";
 import type { KulalaOperator } from "./types/operator";
 import { kulalaOperatorNames } from "./types/operator";
@@ -65,13 +67,18 @@ export const getOperator = (
 const isOperatorError = (obj: unknown): obj is KulalaError =>
   typeof obj === "object" && obj !== null && "errorMessage" in obj;
 
-/** Operators (`# @…` / `// @…`) before the first `###` block marker. */
+/** Operators (`# @…` / `// @…`) before the first request or `###` block marker. */
 export function extractFileHeaderOperators(content: string): KulalaOperator[] {
   const out: KulalaOperator[] = [];
   let lineIdx = 0;
   for (const line of content.split("\n")) {
     const t = line.trim();
-    if (t.startsWith("###")) break;
+    if (
+      t.startsWith("###") ||
+      isRequestLine(line) ||
+      isPreRequestScriptLine(line)
+    )
+      break;
     if (line.startsWith("# @") || line.startsWith("// @")) {
       const op = getOperator(line, lineIdx);
       if (!isOperatorError(op)) out.push(op);

--- a/packages/core/src/lib/parser/parser.test.ts
+++ b/packages/core/src/lib/parser/parser.test.ts
@@ -2,6 +2,79 @@ import { expect, test } from "bun:test";
 import { resolveVariables, substituteInString } from "../variables";
 import { getDocument } from "./parser";
 
+test("parser: first request does not require a block delimiter", async () => {
+  const content = `GRAPHQL https://api.github.com/graphql HTTP/1.1
+Accept: application/json
+
+query User() {
+  viewer {
+    bio
+  }
+}`;
+
+  const doc = await getDocument(content);
+  const block = doc.blocks[0];
+
+  expect(doc.blocks).toHaveLength(1);
+  expect(block.errors).toEqual([]);
+  expect(block.name).toBe("REQUEST_001");
+  expect(block.request.method).toBe("GRAPHQL");
+  expect(block.request.url).toBe("https://api.github.com/graphql");
+  expect(block.request.httpVersion).toBe("HTTP/1.1");
+  expect(block.request.body).toEqual({
+    query: `query User() {
+  viewer {
+    bio
+  }
+}`,
+  });
+});
+
+test("parser: implicit first request can be followed by delimited requests", async () => {
+  const content = `GET https://example.com HTTP/1.1
+
+### Next
+GET https://nixos.org HTTP/1.1`;
+
+  const doc = await getDocument(content);
+
+  expect(doc.blocks).toHaveLength(2);
+  expect(doc.blocks[0]?.name).toBe("REQUEST_001");
+  expect(doc.blocks[0]?.request.url).toBe("https://example.com");
+  expect(doc.blocks[1]?.name).toBe("Next");
+  expect(doc.blocks[1]?.request.url).toBe("https://nixos.org");
+});
+
+test("parser: implicit first request starts after file header metadata", async () => {
+  const content = `@TOKEN = header-value
+# @no-log
+
+POST https://example.com HTTP/1.1
+Content-Type: text/plain
+
+@TOKEN = body-value
+# @no-cookie-jar
+run ./not-a-directive.http
+import ./also-not-a-directive.http`;
+
+  const doc = await getDocument(content);
+  const block = doc.blocks[0];
+
+  expect(doc.directives).toEqual([]);
+  expect(doc.fileHeaderVariables).toEqual({ TOKEN: "header-value" });
+  expect(doc.fileHeaderOperators?.map((o) => o.name)).toEqual(["no-log"]);
+  expect(block?.preambleVariables).toBeUndefined();
+  expect(block?.operators).toEqual([]);
+  expect(block?.position).toEqual({ start: 1, end: 10 });
+  expect(block?.contentStartLine).toBe(4);
+  expect(block?.request.body).toBe(
+    `@TOKEN = body-value
+# @no-cookie-jar
+run ./not-a-directive.http
+import ./also-not-a-directive.http`,
+  );
+});
+
 test("parser: GraphQL query with type annotations not parsed as header", async () => {
   const content = `### GQL_WITH_VARIABLES
 

--- a/packages/core/src/lib/parser/parser.ts
+++ b/packages/core/src/lib/parser/parser.ts
@@ -14,7 +14,11 @@ import {
 } from "./operator";
 import type { KulalaError } from "./types/error";
 import type { KulalaScript } from "./types/script";
-import { getInlineScriptConsumedLineCount, getScript } from "./script";
+import {
+  getInlineScriptConsumedLineCount,
+  getScript,
+  isPreRequestScriptLine,
+} from "./script";
 import { getHeader } from "./header";
 import { getBody } from "./body";
 import type { KulalaHeader } from "./types/header";
@@ -31,6 +35,7 @@ import {
   parseAtVariableLine,
 } from "./at-variables";
 import type { KulalaDirective, KulalaRunDirective } from "./types/directive";
+import { isRequestLine } from "./request";
 import { resolve, dirname } from "path";
 const blockRegex = /###(.*?)\n([\s\S]+?)(?=###|$)/g;
 const nameRegex = /### (.+?)\n/;
@@ -55,7 +60,8 @@ const getLineType = (
   lineIdx: number,
   seenBlockTypes: KulalaSeenBlockLineTypes,
 ): KulalaBlockLineType => {
-  if (lineIdx === 0) return { name: "name", lineNumber: lineIdx };
+  if (lineIdx === 0 && line.startsWith("###"))
+    return { name: "name", lineNumber: lineIdx };
   if (line.startsWith("###")) return { name: "name", lineNumber: lineIdx };
   // Redirect response (>> path / >>! path) must be checked before generic body
   if (
@@ -89,11 +95,7 @@ const getLineType = (
     return { name: "operator", lineNumber: lineIdx };
   if (line.startsWith("#") || line.trim().startsWith("//"))
     return { name: "comment", lineNumber: lineIdx };
-  if (
-    line.match(
-      /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT|GRAPHQL|GRPC|WS|WSS|WEBSOCKET) /i,
-    )
-  ) {
+  if (isRequestLine(line)) {
     return { name: "request", lineNumber: lineIdx };
   }
   if (
@@ -123,6 +125,32 @@ const getLineType = (
 const isError = (obj: unknown): obj is KulalaError => {
   return typeof obj === "object" && obj !== null && "errorMessage" in obj;
 };
+
+function findImplicitBlockStart(content: string):
+  | {
+      charIndex: number;
+      lineIndex: number;
+    }
+  | undefined {
+  let charIndex = 0;
+  let firstPreRequestScript:
+    | {
+        charIndex: number;
+        lineIndex: number;
+      }
+    | undefined;
+  const lines = content.split("\n");
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    const line = lines[lineIndex]!;
+    if (firstPreRequestScript === undefined && isPreRequestScriptLine(line)) {
+      firstPreRequestScript = { charIndex, lineIndex };
+    }
+    if (isRequestLine(line))
+      return firstPreRequestScript ?? { charIndex, lineIndex };
+    charIndex += lines[lineIndex]!.length + 1;
+  }
+  return undefined;
+}
 
 const getParsedBlock = async (
   rawBlock: string,
@@ -306,8 +334,12 @@ function extractDirectives(content: string): {
     const line = lines[i]!;
     const trimmed = line.trim();
 
-    // Stop at first block marker
-    if (trimmed.startsWith("###")) {
+    // Stop at first request, pre-request script, or block marker.
+    if (
+      trimmed.startsWith("###") ||
+      isRequestLine(line) ||
+      isPreRequestScriptLine(line)
+    ) {
       break;
     }
 
@@ -395,11 +427,39 @@ const getBlocks = async (
 ): Promise<KulalaBlock[]> => {
   const blocks: KulalaBlock[] = [];
   const rawBlocks = content.matchAll(blockRegex);
+
+  const firstBlockMarker = content.search(/^###/m);
+  const prefix =
+    firstBlockMarker === -1 ? content : content.slice(0, firstBlockMarker);
+  const implicitBlockStart = findImplicitBlockStart(prefix);
+  if (implicitBlockStart) {
+    const rawImplicitBlock = prefix.slice(implicitBlockStart.charIndex);
+    const implicitBlock = await getParsedBlock(
+      rawImplicitBlock,
+      0,
+      {
+        start: 1,
+        end: blockMatchLineCount(prefix),
+      },
+      filepath,
+    );
+    implicitBlock.contentStartLine = implicitBlockStart.lineIndex + 1;
+    blocks.push(implicitBlock);
+  }
+
+  const blockIndexOffset = blocks.length;
   for (const [idx, rawBlock] of Array.from(rawBlocks).entries()) {
     const start = content.substring(0, rawBlock.index).split("\n").length;
     const end = start + blockMatchLineCount(rawBlock[0]) - 1;
     const position = { start, end };
-    blocks.push(await getParsedBlock(rawBlock[0], idx, position, filepath));
+    blocks.push(
+      await getParsedBlock(
+        rawBlock[0],
+        idx + blockIndexOffset,
+        position,
+        filepath,
+      ),
+    );
   }
   return blocks;
 };
@@ -486,12 +546,12 @@ export const getDocument = async (
   // Include block-level parse errors in the document error set.
   for (const block of blocks) {
     for (const err of block.errors ?? []) {
-      const blockStart = block.position?.start ?? 0;
+      const contentStart = block.contentStartLine ?? block.position?.start ?? 0;
       const relLine = err.lineNumber ?? 0;
       allErrors.push({
         ...err,
         blockName: block.name,
-        lineNumber: blockStart + relLine + directiveLinesRemoved,
+        lineNumber: contentStart + relLine + directiveLinesRemoved,
       });
     }
   }

--- a/packages/core/src/lib/parser/request.ts
+++ b/packages/core/src/lib/parser/request.ts
@@ -24,6 +24,8 @@ const getValidHttpMethods = (): KulalaHttpMethodAvailable[] => [
 ];
 
 const HTTP_VERSION = /^HTTP\/\d+(\.\d+)?$/;
+const REQUEST_LINE =
+  /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT|GRAPHQL|GRPC|WS|WSS|WEBSOCKET) /i;
 
 const VALID_HTTP_VERSIONS: KulalaHttpVersion[] = [
   "HTTP/1.0",
@@ -57,6 +59,8 @@ const splitRequestTargetAndVersion = (
 // Check if a line is a request continuation (indented URL part or comment).
 export const isRequestContinuationLine = (line: string): boolean =>
   line.length > 0 && /^\s/.test(line);
+
+export const isRequestLine = (line: string): boolean => REQUEST_LINE.test(line);
 
 /**
  * Parse request line(s).

--- a/packages/core/src/lib/parser/script.ts
+++ b/packages/core/src/lib/parser/script.ts
@@ -15,6 +15,9 @@ function indexOfInlineScriptEnd(contents: string): number {
 export const preRequestScriptMarker = "< ";
 export const postRequestScriptMarker = "> ";
 
+export const isPreRequestScriptLine = (line: string): boolean =>
+  line.startsWith(preRequestScriptMarker);
+
 /** Lines consumed by an inline `{% ... %}` script (including the opening and closing lines). */
 export function getInlineScriptConsumedLineCount(
   line: string,

--- a/packages/core/src/lib/parser/types/block.ts
+++ b/packages/core/src/lib/parser/types/block.ts
@@ -20,6 +20,8 @@ export type KulalaBlock = {
     start: number;
     end: number;
   };
+  /** 1-based file line where parsed request content begins (implicit blocks include file-header lines in `position`). */
+  contentStartLine?: number;
   /** @name=value lines in this block before the request (JetBrains in-file variables). */
   preambleVariables?: Record<string, string>;
   /** @ variables from the start of the .http file this block was parsed from (imports / run file). */

--- a/packages/core/src/lib/runner/resolve-request-from-block.test.ts
+++ b/packages/core/src/lib/runner/resolve-request-from-block.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import { getDocument } from "../parser/parser";
 import { findBlockAtCursor } from "./block";
 import { resolveRequestFromBlock } from "./resolve-request-from-block";
 import { toCurlAtCursor } from "./request-cursor";
+
+const implicitFirstRequestPath = join(
+  import.meta.dir,
+  "../../../../../http-example-files/implicit-first-request.http",
+);
 
 const graphqlContent = `### GQL_TEST
 
@@ -31,6 +38,78 @@ describe("resolveRequestFromBlock", () => {
     expect(result.request.method).toBe("POST");
     expect(result.request.headers["Content-Type"]).toBe("application/json");
     expect(result.request.body).toContain("query");
+  });
+
+  test("cursor on pre-request script resolves implicit first request", async () => {
+    const content = `< {%
+  request.variables.set("users", [
+    { name: "Alice" },
+    { name: "Bob" },
+  ])
+%}
+
+GET https://httpbin.org/get?user={{users[*].name}} HTTP/1.1
+Content-Type: application/json`;
+    const doc = await getDocument(content, "/test.http");
+
+    expect(doc.blocks[0]?.position).toEqual({ start: 1, end: 9 });
+    expect(doc.blocks[0]?.scripts.preRequest).toHaveLength(1);
+    expect(findBlockAtCursor(doc, { line: 1, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 6, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 8, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+  });
+
+  test("cursor on doc-scoped variables resolves implicit first request", async () => {
+    const content = `@MY_VAR = 123
+# @kulala-curl--insecure
+
+< {%
+  request.variables.set("users", [
+    { name: "Alice" },
+    { name: "Bob" },
+  ])
+%}
+
+GET https://httpbin.org/get?user={{users[*].name}} HTTP/1.1
+Content-Type: application/json`;
+    const doc = await getDocument(content, "/test.http");
+
+    expect(doc.blocks[0]?.position).toEqual({ start: 1, end: 12 });
+    expect(doc.blocks[0]?.contentStartLine).toBe(4);
+    expect(doc.blocks[0]?.scripts.preRequest).toHaveLength(1);
+    expect(findBlockAtCursor(doc, { line: 1, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 6, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 8, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+  });
+
+  test("cursor on file-header lines resolves implicit-first-request.http", async () => {
+    const content = readFileSync(implicitFirstRequestPath, "utf8");
+    const doc = await getDocument(content, implicitFirstRequestPath);
+
+    expect(doc.blocks[0]?.position).toEqual({ start: 1, end: 13 });
+    expect(doc.blocks[0]?.contentStartLine).toBe(4);
+    expect(findBlockAtCursor(doc, { line: 1, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 2, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 11, column: 1 })?.name).toBe(
+      "REQUEST_001",
+    );
+    expect(findBlockAtCursor(doc, { line: 14, column: 1 })?.name).toBe("FOO");
   });
 });
 

--- a/packages/core/src/lib/runner/scripts.ts
+++ b/packages/core/src/lib/runner/scripts.ts
@@ -234,7 +234,8 @@ function buildConsoleOrigin(args: {
   tempCallsite?: ParsedTempCallsite | undefined;
 }): KulalaScriptConsoleOrigin {
   const { script, block, phase, httpDocumentPath, tempCallsite } = args;
-  const httpDirectiveLine = block.position.start + script.lineNumber;
+  const httpDirectiveLine =
+    (block.contentStartLine ?? block.position.start) + script.lineNumber;
   let originFile: string;
   if (script.source === "inline") {
     const fp = script.filepath?.trim() ?? "";


### PR DESCRIPTION
## Summary

- parse request content before the first `###` as an implicit block
- include leading pre-request scripts in implicit first request blocks, so cursor selection works above the request line
- stop file-level directives, variables, and operators at the first request/pre-request script/block marker
- keep existing `###`-delimited block parsing unchanged
- add regression tests for GraphQL first requests, mixed implicit/delimited requests, header/body boundary handling, and cursor selection on a leading pre-request script

Fixes https://github.com/mistweaverco/kulala-core/issues/44

Context from nixpkgs update/regression report:
- https://github.com/NixOS/nixpkgs/pull/523651#discussion_r3295088672
- https://github.com/NixOS/nixpkgs/pull/523733

## Test

- `bun test packages/core/src/lib/parser/parser.test.ts packages/core/src/lib/parser/import-run.test.ts packages/core/src/lib/parser/request.test.ts packages/core/src/lib/runner/resolve-request-from-block.test.ts`
- `bunx prettier --check packages/core/src/lib/parser/parser.ts packages/core/src/lib/parser/parser.test.ts packages/core/src/lib/parser/at-variables.ts packages/core/src/lib/parser/operator.ts packages/core/src/lib/parser/request.ts packages/core/src/lib/parser/script.ts packages/core/src/lib/runner/resolve-request-from-block.test.ts`
- `bunx eslint packages/core/src/lib/parser/parser.ts packages/core/src/lib/parser/parser.test.ts packages/core/src/lib/parser/at-variables.ts packages/core/src/lib/parser/operator.ts packages/core/src/lib/parser/request.ts packages/core/src/lib/parser/script.ts packages/core/src/lib/runner/resolve-request-from-block.test.ts`

Note: full `bun test` currently fails on current `main` failures unrelated to this PR: `block.test.ts` import-all fixture expectations and recursive `httpDoRequestFromBlock` helper failures in `doRequest.test.ts`.