### PR TITLE
fix(parser): await stdio writes before process.exit (stdout truncation past pipe buffer)

### DIFF
--- a/packages/core/src/lib/parser/index.ts
+++ b/packages/core/src/lib/parser/index.ts
@@ -109,7 +109,7 @@ const kulalaParser: KulalaParser = {
               },
             ],
           };
-          writeRequestResponseToStdout(successResponse);
+          await writeRequestResponseToStdout(successResponse);
         } catch (error) {
           const errorResponse: KulalaResponseWrapper = {
             type: "error",
@@ -121,7 +121,7 @@ const kulalaParser: KulalaParser = {
               } as KulalaRequestErrorResponse & { promptId: string },
             ],
           };
-          writeRequestResponseToStdout(errorResponse);
+          await writeRequestResponseToStdout(errorResponse);
         }
         break;
       }
@@ -131,13 +131,13 @@ const kulalaParser: KulalaParser = {
             stdIn.op,
             stdIn as Record<string, unknown>,
           );
-          writeRequestResponseToStdout({
+          await writeRequestResponseToStdout({
             type: "crypto",
             success: true,
             value,
           });
         } catch (error) {
-          writeRequestResponseToStdout({
+          await writeRequestResponseToStdout({
             type: "crypto",
             success: false,
             error: error instanceof Error ? error.message : String(error),
@@ -158,7 +158,7 @@ const kulalaParser: KulalaParser = {
           });
           const rawBody =
             typeof res.body === "string" ? res.body : res.body.toString("utf8");
-          writeRequestResponseToStdout({
+          await writeRequestResponseToStdout({
             type: "http_request",
             success: true,
             status: res.statusCode,
@@ -167,7 +167,7 @@ const kulalaParser: KulalaParser = {
             url: res.url,
           });
         } catch (error) {
-          writeRequestResponseToStdout({
+          await writeRequestResponseToStdout({
             type: "http_request",
             success: false,
             error: error instanceof Error ? error.message : String(error),
@@ -183,7 +183,10 @@ const kulalaParser: KulalaParser = {
         } else {
           for (const name of names) deleteVariable("global", name);
         }
-        writeRequestResponseToStdout({ type: "clear_globals", success: true });
+        await writeRequestResponseToStdout({
+          type: "clear_globals",
+          success: true,
+        });
         break;
       }
       case "environments": {

--- a/packages/core/src/lib/parser/lib/helpers/helpers.test.ts
+++ b/packages/core/src/lib/parser/lib/helpers/helpers.test.ts
@@ -1,0 +1,93 @@
+import { expect, test } from "bun:test";
+import { join } from "node:path";
+
+const HELPER_PATH = join(import.meta.dir, "index.ts");
+const COUNT = 200;
+const ITEM_SIZE = 2500;
+
+/**
+ * Regression test for stdout / stderr truncation past the kernel pipe
+ * buffer when `process.exit` races a buffered Bun stdio write.
+ *
+ * The bug: `Bun.stdout.write(...); process.exit(0)` discards anything
+ * still queued in the runtime's stdio buffer at the moment of exit. On
+ * Linux a POSIX pipe holds at most ~64 KB synchronously, so result
+ * wrappers larger than that are silently truncated when read by a
+ * pipe consumer (e.g. kulala.nvim's `vim.system` bridge).
+ *
+ * These tests spawn a child process that calls the helper with a
+ * ~500 KB payload, drain its stdio chunk-by-chunk, and assert that
+ * every byte the helper intended to write was actually received.
+ */
+
+function buildPayload(type: string, pad: string): unknown {
+  return {
+    type,
+    data: Array.from({ length: COUNT }, (_, i) => ({
+      i,
+      pad: pad.repeat(ITEM_SIZE),
+    })),
+  };
+}
+
+/** Child script — generates the payload in-process so the parent doesn't have
+ *  to pass it via argv (avoids E2BIG for large payloads). */
+function childScript(helperName: string, pad: string): string {
+  return `
+    import { ${helperName} } from "${HELPER_PATH}";
+    const payload = {
+      type: "${helperName === "writeRequestResponseToStderr" ? "error" : "responses"}",
+      data: Array.from({ length: ${COUNT} }, (_, i) => ({
+        i,
+        pad: "${pad}".repeat(${ITEM_SIZE}),
+      })),
+    };
+    await ${helperName}(payload);
+  `;
+}
+
+async function drain(stream: ReadableStream<Uint8Array>): Promise<number> {
+  let total = 0;
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) total += value.length;
+  }
+  return total;
+}
+
+test("writeRequestResponseToStdout flushes large payloads before exit", async () => {
+  const expected = JSON.stringify(buildPayload("responses", "x"), null, 2);
+
+  // sanity: payload must exceed the kernel pipe buffer to exercise the bug.
+  expect(expected.length).toBeGreaterThan(65_536);
+
+  const proc = Bun.spawn({
+    cmd: ["bun", "-e", childScript("writeRequestResponseToStdout", "x")],
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const received = await drain(proc.stdout);
+  await proc.exited;
+
+  expect(proc.exitCode).toBe(0);
+  expect(received).toBe(expected.length);
+});
+
+test("writeRequestResponseToStderr flushes large payloads before exit", async () => {
+  const expected = JSON.stringify(buildPayload("error", "y"), null, 2);
+
+  expect(expected.length).toBeGreaterThan(65_536);
+
+  const proc = Bun.spawn({
+    cmd: ["bun", "-e", childScript("writeRequestResponseToStderr", "y")],
+    stdout: "inherit",
+    stderr: "pipe",
+  });
+  const received = await drain(proc.stderr);
+  await proc.exited;
+
+  expect(proc.exitCode).toBe(1);
+  expect(received).toBe(expected.length);
+});

--- a/packages/core/src/lib/parser/lib/helpers/index.ts
+++ b/packages/core/src/lib/parser/lib/helpers/index.ts
@@ -1,7 +1,9 @@
 import type { KulalaDocument, KulalaStdinParsed } from "../../types";
 
-export const writeRequestResponseToStderr = (res: unknown): void => {
-  Bun.stderr.write(JSON.stringify(res, null, 2));
+export const writeRequestResponseToStderr = async (
+  res: unknown,
+): Promise<void> => {
+  await Bun.write(Bun.stderr, JSON.stringify(res, null, 2));
   process.exit(1);
 };
 
@@ -10,8 +12,10 @@ export const writeErrorToStderr = (error: string): void => {
   Bun.stderr.write(JSON.stringify({ success: false, error }, null, 2) + "\n");
 };
 
-export const writeRequestResponseToStdout = (res: unknown): void => {
-  Bun.stdout.write(JSON.stringify(res, null, 2));
+export const writeRequestResponseToStdout = async (
+  res: unknown,
+): Promise<void> => {
+  await Bun.write(Bun.stdout, JSON.stringify(res, null, 2));
   process.exit(0);
 };
 

--- a/packages/core/src/lib/runner/index.ts
+++ b/packages/core/src/lib/runner/index.ts
@@ -213,10 +213,10 @@ export const KulalaRunner = () => {
     ): Promise<void> => {
       const res = await runDocument(doc, limit, options);
       if (res.type === "error") {
-        writeRequestResponseToStderr(res);
+        await writeRequestResponseToStderr(res);
         return;
       }
-      writeRequestResponseToStdout(res);
+      await writeRequestResponseToStdout(res);
     },
   };
 };


### PR DESCRIPTION
## Summary

`Bun.stdout.write` / `Bun.stderr.write` to a POSIX pipe queue bytes in the runtime's stdio buffer and return before the kernel has accepted them. `process.exit` then terminates the process **without draining that queue**, so any bytes still buffered are silently dropped. On Linux, the kernel pipe holds whatever was flushed synchronously — typically just the first ~64 KB (one pipe buffer's worth).

In practice this truncates large result wrappers when callers read `kulala-core`'s stdout via a pipe — most notably `kulala.nvim`'s bridge (`kulala_core_bridge.lua`), where the truncated JSON fails to decode and the user sees:

```
Status: FAIL
Errors in request ... at line: N
invalid kulala-core run output
```

The bite happens any time a `.http` file's output exceeds ~64 KB — roughly 100 simple GETs, or much fewer with large response bodies.

## Fix

`writeRequestResponseToStdout` and `writeRequestResponseToStderr` (in `packages/core/src/lib/parser/lib/helpers/index.ts`) are the canonical exit points used by both the parser (7 call sites) and the runner (2 call sites). This patch switches them from the fire-and-forget `Bun.{stdout,stderr}.write(...)` followed immediately by `process.exit` to:

```ts
await Bun.write(Bun.{stdout,stderr}, JSON.stringify(res, null, 2));
process.exit(0 /* or 1 */);
```

`Bun.write(destination, data)` returns `Promise<number>` and resolves only after the data is fully flushed to the kernel, so `process.exit` no longer races the buffered tail.

The two helpers become `async` and the nine call sites are updated to `await` them. All nine are already inside `async` functions (`KulalaParser.parse` and `KulalaRunner.run`), so no caller-of-callers needed to change.

`writeErrorToStderr` and `writeToStderr`/`writeToStdout` (the non-exit helpers in the same file) are intentionally left alone — they don't call `process.exit` and the data lives long enough for the runtime's normal drain to handle.

## Reproduction

Self-contained repro repo:
https://github.com/LORDBABUINO/kulala-core-stdout-truncation-repro

Quick inline check with the released v0.5.1 binary vs this PR:

```sh
# tiny local test server returning JSON of any size
node -e "require('http').createServer((req,res)=>{
  const n=parseInt((req.url.match(/\/n\/(\d+)/)||[])[1]||100);
  res.writeHead(200,{'Content-Type':'application/json'});
  res.end(JSON.stringify({ok:true,pad:'x'.repeat(Math.max(0,n-20))}));
}).listen(8765)" &

# build the patched binary
bun run build

# 117 small GETs → ~673 KB of result JSON (well past the 64 KB pipe buffer)
python3 -c '
import json
content = "\n".join(
  f"### Probe {i}\n\nGET http://localhost:8765/n/4000 HTTP/1.1\nAccept: application/json\n"
  for i in range(1, 118)
) + "\n"
print(json.dumps({"action": "run", "content": content}))
' > /tmp/big-payload.json
```

Slow-drain pipe (`dd bs=1`) makes the truncation deterministic:

| Binary                         | Run 1  | Run 2  | Run 3  | Run 4  | Run 5  |
|--------------------------------|--------|--------|--------|--------|--------|
| `kulala-core 0.5.1` (released) | 65536  | 65536  | 65536  | 65536  | 65536  |
| This PR                        | 673158 | 673108 | 673635 | 673090 | 673311 |

(Per-run variance on this PR is from response timestamps; all five fully decode as valid JSON with 117 items.)

## Test suite

`bun test` shows the same 4 pre-existing failures as `main` (all `curl transport > … redirects`) — none caused by this patch, **plus 2 new passing tests** added in this PR:

```
330 pass
  4 fail
Ran 334 tests across 35 files.
```

`bun run lint` (`tsc --noEmit && prettier --check . && eslint .`) is clean.

### Regression test

Added `packages/core/src/lib/parser/lib/helpers/helpers.test.ts` (2 cases — one for stdout, one for stderr). Each spawns a child `bun -e` process that calls the helper with a ~500 KB payload (well past the kernel pipe buffer), drains the relevant stdio chunk-by-chunk, and asserts every byte was received.

Verified deterministic in both directions (5 consecutive runs each):

|    | Run 1 | Run 2 | Run 3 | Run 4 | Run 5 |
|---|---|---|---|---|---|
| Buggy (`upstream/main`) | 2 fail (truncated 255808 / 475072) | 2 fail | 2 fail (219264 / 219264) | 2 fail (219264 / 219264) | 2 fail (292352 / 475072) |
| Fixed (this PR) | 2 pass | 2 pass | 2 pass | 2 pass | 2 pass |

(The child generates the payload in-process from size parameters rather than receiving it via argv, to avoid `E2BIG`.)

## Environment where reproduced

| Component                                          | Version                                                         |
|---------------------------------------------------|-----------------------------------------------------------|
| OS / kernel                                           | Arch Linux, Linux 7.0.10-arch1-1 (x86_64)  |
| Bun                                                       | 1.3.14                                                           |
| Node.js (same truncation reproduces) | v20.20.2 and v24.15.0                                  |
| Default Linux pipe buffer                      | 65 536 bytes (16 × 4 KiB pages)                  |
| Released `kulala-core`                         | 0.5.1                                                              |
| `kulala.nvim`                                         | 713cf9d (current `main`)                               |
| Neovim                                                 | 0.12.2 (incidental — bug is upstream of it)   |

The threshold lines up cleanly with the kernel pipe buffer: on platforms or configurations with a different default, the cliff would move accordingly. The fix is independent of pipe-buffer size since it waits for the full flush regardless.

---

I'm happy to iterate on the fix shape if you'd prefer a different style — e.g., keeping the helpers sync and doing the flush at the CLI entry instead, or using `node:fs.writeSync` for a sync option that doesn't propagate `async` through callers.
