### PR TITLE
feat(scripts): add shared-headers to the $kulala script API

### DIFF
--- a/http-example-files/shared-headers.http
+++ b/http-example-files/shared-headers.http
@@ -1,11 +1,22 @@
 ### First
 
-# If you run all requests (not one by one),
-# this is considered as a shared header,
-# and the header will be sent in all requests.
+# WARN:
+# Jetbrains client.global.headers.set("X-Kulala", "Family");
+# Only works for all requests in one flow, not for each request separately.
+# One flow is when you run all requests in the file at once.
+
+# INFO:
+# Kulala supports client.global.headers.set() with the same limitation,
+# but also has $kulala.client.global.headers.set()
+# which works for all requests in the same file,
+# even if you run them one by one.
+
+# In this example,
+# we set the header "X-Kulala" with the value "Family" for all requests in
+# the file using $kulala.client.global.headers.set().
 
 < {%
-  client.global.headers.set("X-Kulala", "Family");
+  $kulala.client.global.headers.set("X-Kulala", "Family");
 %}
 
 GET https://echo.getkulala.net/get HTTP/1.1

--- a/packages/core/src/lib/runner/doRequest.ts
+++ b/packages/core/src/lib/runner/doRequest.ts
@@ -24,6 +24,7 @@ import {
   saveHistoryEntry,
   setVariable,
   storeCookiesFromResponse,
+  getVariable,
 } from "../persistence";
 import {
   buildCustomPromptResponse,
@@ -90,6 +91,18 @@ export type DoRequestFromBlockResult =
   | KulalaPromptResponse
   | KulalaSkippedResponse
   | KulalaWebSocketPlanResponse;
+
+const CLIENT_GLOBAL_HEADERS_VAR = "__kulala_client_global_headers__";
+
+function readClientGlobalHeaders(): Record<string, string> {
+  const v = getVariable("global", CLIENT_GLOBAL_HEADERS_VAR);
+  if (!v || typeof v !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof raw === "string") out[k] = raw;
+  }
+  return out;
+}
 
 export type DoRequestFromBlockOptions = {
   /** 0-based collection loop index (JetBrains request.iteration()). */
@@ -611,14 +624,26 @@ export async function doRequestFromBlock(
     ) {
       headers.Accept = accept;
     }
+    // Persisted client global headers are applied to all outgoing requests,
+    // but must not override explicit request headers.
+    {
+      const explicitLc = new Set(
+        Object.keys(headers).map((k) => k.toLowerCase()),
+      );
+      const clientHeaders = readClientGlobalHeaders();
+      for (const [k, v] of Object.entries(clientHeaders)) {
+        if (!explicitLc.has(k.toLowerCase())) headers[k] = v;
+      }
+    }
     // JetBrains parity: global headers are applied implicitly to outgoing requests
     // within the same execution flow, but should not override explicit request headers.
     if (flow?.globalHeaders) {
-      const existingLc = new Set(
+      const explicitLc = new Set(
         Object.keys(headers).map((k) => k.toLowerCase()),
       );
+      // Allow flow-local headers to override persisted client headers (but not explicit request headers).
       for (const [k, v] of Object.entries(flow.globalHeaders)) {
-        if (!existingLc.has(k.toLowerCase())) headers[k] = v;
+        if (!explicitLc.has(k.toLowerCase())) headers[k] = v;
       }
     }
     if (needsAsyncSubstitution || Object.keys(mutableVars).length > 0) {

--- a/packages/core/src/lib/runner/kulala-script-api.ts
+++ b/packages/core/src/lib/runner/kulala-script-api.ts
@@ -4,12 +4,43 @@ import {
   resolvePromptVariableValue,
   type KulalaPromptInputType,
 } from "./custom-prompt";
+import { getVariable, setVariable } from "../persistence";
 import { ScriptPromptError } from "./script-prompt-error";
 import { ScriptReplayError, ScriptSkipError } from "./script-control-error";
 
 export type KulalaPromptOptions = {
   type?: KulalaPromptInputType;
 };
+
+const CLIENT_GLOBAL_HEADERS_VAR = "__kulala_client_global_headers__";
+
+function normalizeHeaderName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function setHeaderCaseInsensitive(
+  map: Record<string, string>,
+  name: string,
+  value: string | null,
+): void {
+  const targetLc = normalizeHeaderName(name);
+  for (const k of Object.keys(map)) {
+    if (normalizeHeaderName(k) === targetLc) delete map[k];
+  }
+  if (value !== null) {
+    map[name] = value;
+  }
+}
+
+function loadClientGlobalHeaders(): Record<string, string> {
+  const v = getVariable("global", CLIENT_GLOBAL_HEADERS_VAR);
+  if (!v || typeof v !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof raw === "string") out[k] = raw;
+  }
+  return out;
+}
 
 export type KulalaScriptApi = {
   /**
@@ -26,6 +57,20 @@ export type KulalaScriptApi = {
     skip: () => void;
     /** Re-run this request from pre-request scripts (pre- and post-request). */
     replay: () => void;
+  };
+  /**
+   * Client-scoped helpers.
+   *
+   * These are persisted across runs (unlike `client.global.headers`, which is per execution flow).
+   */
+  client: {
+    global: {
+      headers: {
+        set: (headerName: string, headerValue: string) => void;
+        get: (headerName: string) => string | undefined;
+        clear: (headerName: string) => void;
+      };
+    };
   };
 };
 
@@ -89,6 +134,54 @@ export function buildKulalaScriptApi(ctx: {
       },
       replay() {
         throw new ScriptReplayError();
+      },
+    },
+    client: {
+      global: {
+        headers: {
+          set(headerName: string, headerValue: string) {
+            if (
+              typeof headerName !== "string" ||
+              headerName.trim().length === 0
+            ) {
+              throw new Error(
+                "$kulala.client.global.headers.set: headerName must be a non-empty string",
+              );
+            }
+            const headers = loadClientGlobalHeaders();
+            setHeaderCaseInsensitive(headers, headerName, String(headerValue));
+            setVariable("global", CLIENT_GLOBAL_HEADERS_VAR, headers);
+          },
+          get(headerName: string) {
+            if (
+              typeof headerName !== "string" ||
+              headerName.trim().length === 0
+            ) {
+              throw new Error(
+                "$kulala.client.global.headers.get: headerName must be a non-empty string",
+              );
+            }
+            const lc = normalizeHeaderName(headerName);
+            const headers = loadClientGlobalHeaders();
+            for (const [k, v] of Object.entries(headers)) {
+              if (normalizeHeaderName(k) === lc) return v;
+            }
+            return undefined;
+          },
+          clear(headerName: string) {
+            if (
+              typeof headerName !== "string" ||
+              headerName.trim().length === 0
+            ) {
+              throw new Error(
+                "$kulala.client.global.headers.clear: headerName must be a non-empty string",
+              );
+            }
+            const headers = loadClientGlobalHeaders();
+            setHeaderCaseInsensitive(headers, headerName, null);
+            setVariable("global", CLIENT_GLOBAL_HEADERS_VAR, headers);
+          },
+        },
       },
     },
   };

--- a/packages/core/src/lib/runner/resolve-request-from-block.ts
+++ b/packages/core/src/lib/runner/resolve-request-from-block.ts
@@ -5,6 +5,7 @@ import { getEffectiveOperators } from "./effective-operators";
 import { OAuth2Manager } from "../auth/oauth2/manager";
 import { OAuth2PromptError } from "../auth/oauth2/prompt-error";
 import { ScriptPromptError } from "./script-prompt-error";
+import { getVariable } from "../persistence";
 import {
   MAX_SCRIPT_REPLAYS,
   ScriptReplayError,
@@ -49,6 +50,18 @@ import type {
   KulalaRequestSent,
   VariableResolver,
 } from "./types";
+
+const CLIENT_GLOBAL_HEADERS_VAR = "__kulala_client_global_headers__";
+
+function readClientGlobalHeaders(): Record<string, string> {
+  const v = getVariable("global", CLIENT_GLOBAL_HEADERS_VAR);
+  if (!v || typeof v !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [k, raw] of Object.entries(v as Record<string, unknown>)) {
+    if (typeof raw === "string") out[k] = raw;
+  }
+  return out;
+}
 
 export type ResolvedRequestPreview = {
   method: string;
@@ -223,12 +236,21 @@ export async function resolveRequestFromBlock(
   ) {
     headers.Accept = accept;
   }
+  {
+    const explicitLc = new Set(
+      Object.keys(headers).map((k) => k.toLowerCase()),
+    );
+    const clientHeaders = readClientGlobalHeaders();
+    for (const [k, v] of Object.entries(clientHeaders)) {
+      if (!explicitLc.has(k.toLowerCase())) headers[k] = v;
+    }
+  }
   if (flow?.globalHeaders) {
-    const existingLc = new Set(
+    const explicitLc = new Set(
       Object.keys(headers).map((k) => k.toLowerCase()),
     );
     for (const [k, v] of Object.entries(flow.globalHeaders)) {
-      if (!existingLc.has(k.toLowerCase())) headers[k] = v;
+      if (!explicitLc.has(k.toLowerCase())) headers[k] = v;
     }
   }
   if (needsAsyncSubstitution || Object.keys(activeVars).length > 0) {

--- a/packages/core/src/lib/runner/shared-headers.test.ts
+++ b/packages/core/src/lib/runner/shared-headers.test.ts
@@ -71,3 +71,61 @@ GET ${baseUrl}/get HTTP/1.1
     expect(headers["x-kulala"] ?? headers["X-Kulala"]).toBe("Family");
   }
 });
+
+test("$kulala.client.global.headers.set persists across runs", async () => {
+  const content1 = `### First
+
+< {%
+  $kulala.client.global.headers.set("X-Kulala", "Family");
+%}
+
+GET ${baseUrl}/get HTTP/1.1
+`;
+  const content2 = `### Second
+
+GET ${baseUrl}/get HTTP/1.1
+`;
+  const doc1 = await getDocument(
+    content1,
+    "/tmp/persisted-shared-headers-1.http",
+  );
+  const res1 = await runDocument(doc1);
+  expect(res1.type).toBe("responses");
+  expect(res1.data).toHaveLength(1);
+
+  const doc2 = await getDocument(
+    content2,
+    "/tmp/persisted-shared-headers-2.http",
+  );
+  const res2 = await runDocument(doc2);
+  expect(res2.type).toBe("responses");
+  expect(res2.data).toHaveLength(1);
+
+  const item = res2.data[0]!;
+  expect(item).toHaveProperty("success", true);
+  if (!item.success || !("body" in item) || item.body.type !== "json") return;
+  const headers = item.body.content.headers as Record<string, string>;
+  expect(headers["x-kulala"] ?? headers["X-Kulala"]).toBe("Family");
+});
+
+test("$kulala.client.global.headers.get returns persisted value", async () => {
+  const content = `### First
+
+< {%
+  $kulala.client.global.headers.set("X-Kulala", "Family");
+  client.assert($kulala.client.global.headers.get("x-kulala") === "Family");
+  client.assert($kulala.client.global.headers.get("X-KULALA") === "Family");
+  client.assert($kulala.client.global.headers.get("does-not-exist") === undefined);
+%}
+
+GET ${baseUrl}/get HTTP/1.1
+`;
+  const doc = await getDocument(
+    content,
+    "/tmp/persisted-shared-headers-get.http",
+  );
+  const res = await runDocument(doc);
+  expect(res.type).toBe("responses");
+  expect(res.data).toHaveLength(1);
+  expect(res.data[0]).toHaveProperty("success", true);
+});


### PR DESCRIPTION
Jetbrains client.global.headers.set("X-Kulala", "Family"); Only works for all requests in one flow, not for each request separately. One flow is when you run all requests in the file at once.

Kulala supports client.global.headers.set() with the same limitation, but also has $kulala.client.global.headers.set()
which works for all requests in the same file,
even if you run them one by one.

Closes https://github.com/mistweaverco/kulala.nvim/issues/889