### PR TITLE
feat(multipart/form-data): CRLF after closing boundary for compatibility

### DIFF
--- a/packages/core/src/lib/runner/body.test.ts
+++ b/packages/core/src/lib/runner/body.test.ts
@@ -278,7 +278,7 @@ test("resolveInlineBodyFileRefs keeps same-line suffix after path", async () => 
 
   const template = `< ./f.txt --end--\n`;
   const out = await resolveInlineBodyFileRefs(template, dir);
-  expect(out.toString("utf8")).toBe("Z\r\n--end--");
+  expect(out.toString("utf8")).toBe("Z\r\n--end--\r\n");
 });
 
 test("resolveInlineBodyFileRefs: blank line after file ref yields single LF before next boundary", async () => {
@@ -297,8 +297,8 @@ test("resolveInlineBodyFileRefs: blank line after file ref yields single LF befo
     "--b--",
   ].join("\n");
   const out = (await resolveInlineBodyFileRefs(template, dir)).toString("utf8");
-  expect(out).toContain("BODY\r\n--b--");
-  expect(out).not.toContain("BODY\r\n\r\n--b--");
+  expect(out).toContain("BODY\r\n--b--\r\n");
+  expect(out).not.toContain("BODY\r\n\r\n--b--\r\n");
 });
 
 test("resolveInlineBodyFileRefs: file with trailing LF then boundary line — one LF before --", async () => {
@@ -333,7 +333,7 @@ test("resolveInlineBodyFileRefs: same-line closing boundary without template new
 
   const template = "< ./f.txt --boundary--";
   const out = (await resolveInlineBodyFileRefs(template, dir)).toString("utf8");
-  expect(out).toBe("kulala familiy\n\r\n--boundary--");
+  expect(out).toBe("kulala familiy\n\r\n--boundary--\r\n");
 });
 
 test("resolveInlineBodyFileRefs: IntelliJ-style multi-part template is busboy-parseable", async () => {
@@ -390,6 +390,6 @@ test("resolveInlineBodyFileRefs: trailing LF in file + blank before boundary —
     "--b--",
   ].join("\n");
   const out = (await resolveInlineBodyFileRefs(template, dir)).toString("utf8");
-  expect(out).toContain("BODY\n\r\n--b--");
-  expect(out).not.toContain("BODY\n\n--b--");
+  expect(out).toContain("BODY\n\r\n--b--\r\n");
+  expect(out).not.toContain("BODY\n\n--b--\r\n");
 });

--- a/packages/core/src/lib/runner/body.ts
+++ b/packages/core/src/lib/runner/body.ts
@@ -256,6 +256,8 @@ export async function resolveInlineBodyFileRefs(
     if (nl === -1) break;
     pos = nl + 1;
   }
+  // Support legacy servers that enforce CRLF after the closing boundary.
+  chunks.push(Buffer.from("\r\n", "utf8"));
   return Buffer.concat(chunks);
 }
 


### PR DESCRIPTION
## Summary 

Some webservers particularly legacy ones enforce a CRLF after the closing boundary in a multipart/form-data request even though it's not required as per the RFC 2046 5.1.1. Kulala currently won't work with such server.

Other common tools such as cURL, HTTPie and Postman all add a CRLF after the closing boundary for broader compatibility. It's also still RFC compliant to add the trailing CRLF as an optional epilogue can follow the closing boundary.

## Related Issues

Relates to issue https://github.com/mistweaverco/kulala-core/issues/26 and PR https://github.com/mistweaverco/kulala-core/pull/27

## Changes

- Append `\r\n` to the closing boundary on multipart/fom-data requests

## Testing

Start a simple Netcat to output the received ASCII hex byte stream
```
echo -e 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 3\r\n\r\nfoo' | nc -l 5555 | tail -n 1 | xxd -p
```

### kulala.nvim

``` http
POST http://localhost:5555 HTTP/1.1
Content-Type: multipart/form-data; boundary=foo

--foo
Content-Disposition: form-data; name="foo"

foobarbaz
--foo--
```

- Before: `2d2d666f6f2d2d`
  Ends with `--`
- After: `2d2d666f6f2d2d0d0a`
  Now ends with `2d2d0d0a` or `--\r\n`.

### Other CLI Tools
##### cURL

```
curl -F foo=bar http://localhost:5555
```
`2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d61364768326d65354931694a7a373978756d7a31666f2d2d0d0a`
Ends with `2d2d0d0a` or `--\r\n`

##### HTTPie

```
http --multipart localhost:5555 foo=bar
```
`2d2d32633762316135333839323734653037613238346334633738646230326437662d2d0d0a`
Ends with `2d2d0d0a` or `--\r\n`

## Additional Notes
### Web Frameworks Enforcing CRLF

In particular I'm trying to use kulala.nvim to post multipart/form-data to Dancer2 - a Perl web framework built upon Plack and running into the issue outlined here. Trying to post to this backend throws with:

`End of stream encountered while parsing closing boundary at /usr/local/share/perl5/site_perl/HTTP/Entity/Parser/MultiPart.pm line 157.
 at /usr/share/perl5/core_perl/Carp.pm line 291
	Carp::croak('End of stream encountered while parsing closing boundary') called at /usr/local/share/perl5/site_perl/HTTP/MultiPartParser.pm line 174...`

This line https://metacpan.org/dist/HTTP-MultiPartParser/source/lib/HTTP/MultiPartParser.pm#L174 and the surrounding block of code enforces that the closing boundary must terminate with a CRLF.

Having tested kulala.nvim with these changes against Plack it now works as expected.

### Discussion Elsewhere

Some relatively recent discussion around the topic for the Node.js Fetch API that uses Undici https://github.com/nodejs/undici/issues/3624 where they opted to adopt the CRLF after the closing boundary.

It seems like it's generally accepted as a convention to include the CRLF for compatibility reasons even though it isn't required as per the RFC.