### PR TITLE
feat(parser): add serde for parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,10 +10,12 @@
         "@grpc/proto-loader": "0.8.1",
         "@types/bun": "1.3.9",
         "@types/node": "25.5.0",
+        "diff": "^9.0.0",
         "eslint": "9.36.0",
         "eslint-config-prettier": "10.1.8",
         "form-data-encoder": "4.1.0",
         "grpc-reflection-js": "^0.3.0",
+        "picocolors": "^1.1.1",
         "prettier": "3.6.2",
         "typescript-eslint": "8.44.1",
         "wasmoon-lua5.1": "1.18.10",
@@ -190,6 +192,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
@@ -317,6 +321,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/http-example-files/simple.http
+++ b/http-example-files/simple.http
@@ -47,20 +47,19 @@ Cookie: _ga=GA1.2.1903065019.1615319519
 Cookie: NAME2=VALUE2
 
 {
-    "date": "2023-05-10",
-    "temperatureC": 30,
-    "summary": "Warm"
+  "date": "2023-05-10",
+  "temperatureC": 30,
+  "summary": "Warm"
 }
 
 ### GRAPHQL_REQUEST
 
-GRAPHQL  https://httpbin.org/post HTTP/1.1
+GRAPHQL https://httpbin.org/post HTTP/1.1
 
 {
   "username": "user123",
   "password": "pass123"
 }
-
 
 ### NAMED_SIMPLE
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,12 @@
     "@grpc/proto-loader": "0.8.1",
     "@types/bun": "1.3.9",
     "@types/node": "25.5.0",
+    "diff": "^9.0.0",
     "eslint": "9.36.0",
     "eslint-config-prettier": "10.1.8",
     "form-data-encoder": "4.1.0",
     "grpc-reflection-js": "^0.3.0",
+    "picocolors": "^1.1.1",
     "prettier": "3.6.2",
     "typescript-eslint": "8.44.1",
     "wasmoon-lua5.1": "1.18.10"

--- a/packages/core/scripts/manual-serde-inspect.ts
+++ b/packages/core/scripts/manual-serde-inspect.ts
@@ -1,0 +1,37 @@
+import * as fs from "fs/promises";
+import { diffLines } from "diff";
+import pc from "picocolors";
+import { deserializeHttp, serializeHttp } from "./../src/index";
+
+let inputFile = process.argv[2];
+if (!inputFile) {
+  console.error("Usage: bun run manual-serde-inspect.ts <input-file>");
+  process.exit(1);
+}
+
+inputFile = new URL(inputFile, import.meta.url).pathname;
+
+const httpText = await fs.readFile(inputFile, "utf-8");
+const doc = await deserializeHttp(httpText, inputFile);
+const roundTrip = serializeHttp(doc);
+const changes = diffLines(httpText, roundTrip);
+const hasChanges = changes.some((part) => part.added || part.removed);
+if (!hasChanges) {
+  console.log(pc.green("No changes detected!"));
+  process.exit(0);
+}
+changes.forEach((part) => {
+  const lines = part.value.split("\n");
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  lines.forEach((line) => {
+    if (part.added) {
+      console.log(pc.green(`+ ${line}`));
+    } else if (part.removed) {
+      console.log(pc.red(`- ${line}`));
+    } else {
+      console.log(pc.gray(`  ${line}`));
+    }
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export { KulalaParser, writeErrorToStderr } from "./lib/parser";
 export { KulalaRunner } from "./lib/runner";
+export { deserializeHttp, serializeHttp } from "./lib/parser";
+export type { KulalaHttpSerdeSerializeOptions } from "./lib/parser";
 
 export {
   CURL_TOOL,

--- a/packages/core/src/lib/parser/comment.ts
+++ b/packages/core/src/lib/parser/comment.ts
@@ -1,9 +1,11 @@
 import type { KulalaComment } from "./types/comment";
 
 export const getComment = (line: string, lineIdx: number): KulalaComment => {
-  // replace all leading comment markers (# or //) and whitespace to get the content
+  const leadingWhitespace = line.match(/^(\s*)/)?.[1] ?? "";
+  const content = line.replace(/^\s*(?:#|\/\/)\s?/, "");
   return {
-    content: line.replace(/^(?:#|\/\/)\s?/, ""),
+    content,
     lineNumber: lineIdx,
+    ...(leadingWhitespace ? { leadingWhitespace } : {}),
   };
 };

--- a/packages/core/src/lib/parser/index.ts
+++ b/packages/core/src/lib/parser/index.ts
@@ -7,6 +7,8 @@ import {
   writeToStdout,
 } from "./lib/helpers";
 import { getDocument } from "./parser";
+export { deserializeHttp, serializeHttp } from "./serde";
+export type { KulalaHttpSerdeSerializeOptions } from "./serde";
 import { loadEnvironmentCatalog } from "../variables/environments";
 import { dirname } from "path";
 import { continueOAuth2Flow } from "../auth/oauth2/continuation";

--- a/packages/core/src/lib/parser/operator.ts
+++ b/packages/core/src/lib/parser/operator.ts
@@ -22,7 +22,8 @@ export const getOperator = (
   line: string,
   lineIdx: number,
 ): KulalaOperator | KulalaError => {
-  const match = line.match(/^(?:#|\/\/)\s*@([A-z0-9_-]+)(?:\s+(.*))?$/);
+  const match = line.match(/^(?:#|\/\/)\s*@([A-Za-z0-9_-]+)(?:\s+(.*))?$/);
+  const commentStyle = line.trimStart().startsWith("//") ? "//" : "#";
   if (!match) {
     return {
       errorMessage: `Invalid operator syntax at line ${lineIdx + 1}`,
@@ -61,6 +62,7 @@ export const getOperator = (
     name: operatorName as KulalaOperator["name"],
     args: match[2] || undefined,
     lineNumber: lineIdx,
+    commentStyle,
   };
 };
 

--- a/packages/core/src/lib/parser/parser.ts
+++ b/packages/core/src/lib/parser/parser.ts
@@ -210,6 +210,16 @@ const getParsedBlock = async (
       }
     }
 
+    if (
+      line.trim() === "" &&
+      !seenBlockTypes.has("request") &&
+      (result.preamble.length > 0 || result.preambleVariables)
+    ) {
+      result.blankLineBeforeRequest = true;
+      lineIdx++;
+      continue;
+    }
+
     switch (lineType.name) {
       case "name":
         break;
@@ -751,6 +761,9 @@ export const getDocument = async (
           }
           block.runExpander = true;
           (block as BlockWithRunDirective).__fileRunExpander = true;
+          // Preserve the original directive for serializer/round-trip.
+          // The block itself does not represent an executable request when it expands to run-target blocks.
+          (block as BlockWithRunDirective).__runDirective = blockRunDirective;
           delete (block as BlockWithRunDirective).__blockRunDirective;
         }
       }

--- a/packages/core/src/lib/parser/request.ts
+++ b/packages/core/src/lib/parser/request.ts
@@ -187,7 +187,7 @@ export const getRequest = (
     if (!isRequestContinuationLine(line)) break;
     const trimmed = line.trim();
     consumed += 1;
-    if (trimmed.startsWith("# ")) {
+    if (/^#/.test(trimmed) || /^\/\//.test(trimmed)) {
       requestLineParts.push({
         type: "comment",
         comment: getComment(line, startLineIdx + consumed - 1),

--- a/packages/core/src/lib/parser/script.ts
+++ b/packages/core/src/lib/parser/script.ts
@@ -64,7 +64,8 @@ export const getScript = async (
         line.indexOf(`{%${removeLang}`) + removeLang.length + 2,
         closingTag,
       )
-      .trim()
+      .replace(/^\n+/, "")
+      .replace(/\n+$/, "")
       .replaceAll("\\{", "{")
       .replaceAll("\\}", "}");
   } else {
@@ -92,6 +93,7 @@ export const getScript = async (
   return {
     type,
     lang,
+    ...(langTest ? { langExplicit: true } : {}),
     source,
     content,
     filepath,

--- a/packages/core/src/lib/parser/serde.test.ts
+++ b/packages/core/src/lib/parser/serde.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from "bun:test";
+import { getDocument } from "./parser";
+import { serializeHttp } from "./serde";
+import type { KulalaDocument } from "./types/document";
+import type { KulalaBlock } from "./types/block";
+import { join } from "path";
+import { mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+
+function normalizeDoc(doc: KulalaDocument) {
+  const nativeBlocks =
+    doc.nativeBlockCount !== undefined
+      ? doc.blocks.slice(0, doc.nativeBlockCount)
+      : doc.blocks;
+
+  return {
+    fileHeaderVariables: doc.fileHeaderVariables ?? {},
+    vscodeRestclientCompat: doc.vscodeRestclientCompat ?? false,
+    fileHeaderOperators: (doc.fileHeaderOperators ?? []).map((o) => ({
+      name: o.name,
+      args: o.args,
+    })),
+    directives: (doc.directives ?? []).map((d) =>
+      d.type === "import"
+        ? { type: "import" as const, filepath: d.filepath }
+        : {
+            type: "run" as const,
+            target: d.target,
+            variableOverrides: d.variableOverrides ?? {},
+          },
+    ),
+    blocks: nativeBlocks.map(normalizeBlock),
+  };
+}
+
+function normalizeBlock(block: KulalaBlock) {
+  return {
+    name: block.name,
+    preambleVariables: block.preambleVariables ?? {},
+    preamble: (block.preamble ?? []).map((e) =>
+      "name" in e
+        ? { type: "operator" as const, name: e.name, args: e.args }
+        : { type: "comment" as const, content: e.content },
+    ),
+    request: {
+      method: block.request.method,
+      url: block.request.url,
+      httpVersion: block.request.httpVersion,
+      requestLineParts: (block.request.requestLineParts ?? []).map((p) =>
+        p.type === "url"
+          ? { type: "url" as const, line: p.line }
+          : { type: "comment" as const, content: p.comment.content },
+      ),
+      headerSection: (block.request.headerSection ?? []).map((h) =>
+        h.type === "header"
+          ? { type: "header" as const, name: h.name, value: h.value }
+          : { type: "comment" as const, content: h.comment.content },
+      ),
+      body: block.request.body,
+      responseRedirect: block.request.responseRedirect ?? null,
+    },
+    scripts: {
+      preRequest: (block.scripts?.preRequest ?? []).map((s) => ({
+        type: s.type,
+        lang: s.lang,
+        source: s.source,
+        filepath: s.filepath,
+        content: s.content,
+      })),
+      postRequest: (block.scripts?.postRequest ?? []).map((s) => ({
+        type: s.type,
+        lang: s.lang,
+        source: s.source,
+        filepath: s.filepath,
+        content: s.content,
+      })),
+    },
+  };
+}
+
+describe("serde: serializeHttp/deserialize via getDocument", () => {
+  test("round-trips a realistic .http fixture (native blocks only)", async () => {
+    const fixturePath = join(
+      import.meta.dir,
+      "../../../../../http-example-files/scripts.http",
+    );
+    const original = await Bun.file(fixturePath).text();
+
+    const doc1 = await getDocument(original, fixturePath);
+    const serialized = serializeHttp(doc1);
+    const doc2 = await getDocument(serialized, fixturePath);
+
+    expect(normalizeDoc(doc2)).toEqual(normalizeDoc(doc1));
+  });
+
+  test("serializes GRAPHQL bodyFromFile with inline variables suffix", async () => {
+    const content = `### GQL
+
+GRAPHQL https://api.example.com/graphql HTTP/1.1
+
+< ./query.graphql
+
+{ "id": 1 }
+`;
+    const doc1 = await getDocument(content, "/tmp/gql.http");
+    const serialized = serializeHttp(doc1);
+    const doc2 = await getDocument(serialized, "/tmp/gql.http");
+    expect(normalizeDoc(doc2)).toEqual(normalizeDoc(doc1));
+  });
+
+  test("serializes run/import directives and file-header vars/operators", async () => {
+    const content = `@HOST = example.com
+# @kulala-vscode-restclient-compat
+import ./foo.http
+run #BAR (@a=1, @b=two)
+
+### A
+GET https://{{HOST}}/ HTTP/1.1
+`;
+    const doc1 = await getDocument(content, "/tmp/directives.http");
+    const serialized = serializeHttp(doc1);
+    const doc2 = await getDocument(serialized, "/tmp/directives.http");
+    expect(normalizeDoc(doc2)).toEqual(normalizeDoc(doc1));
+  });
+
+  test("preserves block-local run #BLOCK directive (does not serialize expanded request)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kulala-core-serde-"));
+    const filepath = join(dir, "main.http");
+    const content = `### UseLib
+run #LIB (@host=example.com)
+
+### LIB
+GET https://{{host}}/ HTTP/1.1
+`;
+    await writeFile(filepath, content, "utf8");
+
+    const doc1 = await getDocument(content, filepath);
+    const serialized = serializeHttp(doc1);
+    expect(serialized).toContain("### UseLib");
+    expect(serialized).toContain("run #LIB (@host=example.com)");
+    // Ensure we did not inline the expanded request into UseLib
+    const useLibSection =
+      serialized.match(/### UseLib[\s\S]*?(?=\n### |\n?$)/)?.[0] ?? "";
+    expect(useLibSection).not.toMatch(/GET https:\/\//);
+
+    const doc2 = await getDocument(serialized, filepath);
+    expect(normalizeDoc(doc2)).toEqual(normalizeDoc(doc1));
+  });
+
+  test("preserves block-local run ./file.http expander block", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kulala-core-serde-"));
+    const filepath = join(dir, "main.http");
+    const graphqlPath = join(dir, "graphql.http");
+    const content = `### RUN_ALL_GRAPHQL_REQUESTS
+
+run ./graphql.http
+`;
+    await writeFile(
+      graphqlPath,
+      `### GQL
+GRAPHQL https://api.example.com/graphql HTTP/1.1
+`,
+      "utf8",
+    );
+    await writeFile(filepath, content, "utf8");
+
+    const doc1 = await getDocument(content, filepath);
+    const serialized = serializeHttp(doc1);
+    expect(serialized).toContain("### RUN_ALL_GRAPHQL_REQUESTS");
+    expect(serialized).toContain("run ./graphql.http");
+    expect(serialized).not.toContain("GET /");
+
+    const doc2 = await getDocument(serialized, filepath);
+    expect(normalizeDoc(doc2)).toEqual(normalizeDoc(doc1));
+  });
+
+  test("serializeHttp: exactly one blank line after each ###", async () => {
+    const content = `### A
+GET https://example.com HTTP/1.1
+
+### B
+
+run #A
+`;
+    const doc = await getDocument(content, "/tmp/blanklines.http");
+    const serialized = serializeHttp(doc);
+    // For each block, ensure `### <name>\n\n` (one blank line) and not `\n\n\n`.
+    expect(serialized).toContain("### A\n\n");
+    expect(serialized).not.toContain("### A\n\n\n");
+    expect(serialized).toContain("### B\n\n");
+    expect(serialized).not.toContain("### B\n\n\n");
+  });
+
+  test("serializeHttp: emits a blank line after pre-request scripts", async () => {
+    const content = `### S
+< {%
+  client.log("hi")
+%}
+GET https://example.com HTTP/1.1
+`;
+    const doc = await getDocument(content, "/tmp/pre-script-blank.http");
+    const serialized = serializeHttp(doc);
+    expect(serialized).toContain("%}\n\nGET https://example.com HTTP/1.1");
+  });
+
+  test("serializeHttp: emits blank line between post-request scripts", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "kulala-core-serde-"));
+    const filepath = join(dir, "main.http");
+    await writeFile(join(dir, "simple.js"), 'console.log("x")\n', "utf8");
+    const content = `### X
+GET https://example.com HTTP/1.1
+
+> ./simple.js
+> {%
+  client.log("hi")
+%}
+`;
+    const doc = await getDocument(content, filepath);
+    const serialized = serializeHttp(doc);
+    expect(serialized).toContain("> ./simple.js");
+    expect(serialized).toMatch(/>\s+\.\/simple\.js\n\n>\s+\{%/);
+  });
+
+  test("serializeHttp: does not leave trailing blank line for requests without body/scripts", async () => {
+    const content = `### A
+GET https://example.com HTTP/1.1
+`;
+    const doc = await getDocument(content, "/tmp/no-trailing-blank.http");
+    const serialized = serializeHttp(doc);
+    expect(serialized.endsWith("\n")).toBe(true);
+    expect(serialized.endsWith("\n\n")).toBe(false);
+  });
+
+  test("serializeHttp: simple.http has single blank line between blocks", async () => {
+    const fixturePath = join(
+      import.meta.dir,
+      "../../../../../http-example-files/simple.http",
+    );
+    const original = await Bun.file(fixturePath).text();
+    const doc = await getDocument(original, fixturePath);
+    const serialized = serializeHttp(doc);
+    expect(serialized).not.toContain("\n\n\n###");
+    expect(serialized.endsWith("\n\n")).toBe(false);
+  });
+
+  test("serializeHttp: simple.http round-trips without formatting drift", async () => {
+    const fixturePath = join(
+      import.meta.dir,
+      "../../../../../http-example-files/simple.http",
+    );
+    const original = await Bun.file(fixturePath).text();
+    const doc = await getDocument(original, fixturePath);
+    const serialized = serializeHttp(doc);
+
+    expect(serialized).toBe(original);
+    expect(serialized).not.toContain("#   #");
+    expect(serialized).toContain("// @kulala-curl--insecure");
+    expect(serialized).not.toContain("lang=js");
+
+    const queryBlock = doc.blocks.find((b) => b.name.includes("QUERY_PARAMS"));
+    expect(queryBlock?.blankLineBeforeRequest).toBe(true);
+    expect(
+      queryBlock?.request.requestLineParts?.some(
+        (p) => p.type === "comment" && p.comment.content.startsWith("&"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/lib/parser/serde.ts
+++ b/packages/core/src/lib/parser/serde.ts
@@ -1,0 +1,378 @@
+import type { KulalaDocument } from "./types/document";
+import type { KulalaBlock } from "./types/block";
+import type { KulalaDirective } from "./types/directive";
+import type {
+  KulalaHeaderSectionEntry,
+  KulalaRequestLinePart,
+} from "./types/request";
+import type { KulalaOperator } from "./types/operator";
+import type { KulalaScript } from "./types/script";
+import { getDocument } from "./parser";
+import { dirname, isAbsolute, relative, resolve } from "path";
+
+export type KulalaHttpSerdeSerializeOptions = {
+  /**
+   * When false (default), only serializes the first `nativeBlockCount` blocks (the blocks belonging
+   * to the current file). When true, serializes all blocks in `doc.blocks` (including imported/run-expanded).
+   */
+  includeExpandedBlocks?: boolean;
+};
+
+export async function deserializeHttp(
+  content: string,
+  filepath?: string,
+): Promise<KulalaDocument> {
+  return await getDocument(content, filepath);
+}
+
+function serializeOperator(op: KulalaOperator): string {
+  const args =
+    op.args === undefined || op.args === "" ? "" : ` ${String(op.args)}`;
+  const prefix = op.commentStyle ?? "#";
+  return `${prefix} @${op.name}${args}`;
+}
+
+function serializeDirective(d: KulalaDirective): string {
+  if (d.type === "import") return `import ${d.filepath}`;
+  if (d.variableOverrides && Object.keys(d.variableOverrides).length > 0) {
+    const overrides = Object.entries(d.variableOverrides)
+      .map(([k, v]) => `@${k}=${v}`)
+      .join(", ");
+    return `run ${d.target} (${overrides})`;
+  }
+  return `run ${d.target}`;
+}
+
+function maybeQuoteIfHasSpaces(path: string): string {
+  return /\s/.test(path) ? `"${path}"` : path;
+}
+
+function toDocRelativePath(
+  pathFromScript: string,
+  docFilepath?: string,
+): string {
+  if (!docFilepath) return pathFromScript;
+  const docDir = dirname(docFilepath);
+  const abs = isAbsolute(pathFromScript)
+    ? pathFromScript
+    : resolve(process.cwd(), pathFromScript);
+  let rel = relative(docDir, abs);
+  if (rel === "") rel = ".";
+  if (!rel.startsWith(".") && !rel.startsWith("/")) rel = `./${rel}`;
+  return rel;
+}
+
+function serializeScript(script: KulalaScript, docFilepath?: string): string[] {
+  const marker = script.type === "preRequest" ? "<" : ">";
+  if (script.source === "file" && script.filepath) {
+    return [`${marker} ${toDocRelativePath(script.filepath, docFilepath)}`];
+  }
+  const lang = script.langExplicit && script.lang ? ` lang=${script.lang}` : "";
+  return [`${marker} {%${lang}`.trimEnd(), ...script.content.split("\n"), "%}"];
+}
+
+function pushScriptsWithBlankLines(
+  target: string[],
+  scripts: KulalaScript[],
+  docFilepath?: string,
+) {
+  for (let i = 0; i < scripts.length; i++) {
+    if (i > 0) target.push("");
+    target.push(...serializeScript(scripts[i]!, docFilepath));
+  }
+}
+
+function serializeRequestLineParts(
+  method: string,
+  parts: KulalaRequestLinePart[],
+  httpVersion?: string,
+): string[] {
+  const lines: string[] = [];
+  const firstUrl = parts.find((p) => p.type === "url");
+  if (!firstUrl || firstUrl.type !== "url") {
+    // Fallback: caller should handle; keep output parseable.
+    return [`${method} /${httpVersion ? ` ${httpVersion}` : ""}`.trim()];
+  }
+  let firstUrlEmitted = false;
+  for (const p of parts) {
+    if (p.type === "url") {
+      if (!firstUrlEmitted) {
+        lines.push(`${method} ${p.line}`.trimEnd());
+        firstUrlEmitted = true;
+      } else {
+        lines.push(`  ${p.line}`.trimEnd());
+      }
+    } else {
+      const ws = p.comment.leadingWhitespace ?? "  ";
+      lines.push(`${ws}# ${p.comment.content}`.trimEnd());
+    }
+  }
+  if (httpVersion) {
+    lines.push(`  ${httpVersion}`);
+  }
+  return lines;
+}
+
+function serializeHeaderSection(section: KulalaHeaderSectionEntry[]): string[] {
+  const out: string[] = [];
+  for (const entry of section) {
+    if (entry.type === "comment") {
+      out.push(`# ${entry.comment.content}`);
+    } else {
+      out.push(
+        entry.value === undefined
+          ? `${entry.name}:`
+          : `${entry.name}: ${entry.value}`,
+      );
+    }
+  }
+  return out;
+}
+
+function isBodyFromFile(body: unknown): body is { __bodyFromFile: string } {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "__bodyFromFile" in body &&
+    typeof (body as { __bodyFromFile?: unknown }).__bodyFromFile === "string"
+  );
+}
+
+function isGraphQLBody(
+  body: unknown,
+): body is { query: string; variables?: Record<string, unknown> } {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "query" in body &&
+    typeof (body as { query?: unknown }).query === "string"
+  );
+}
+
+function serializeBody(method: string, body: unknown): string[] {
+  if (body === undefined || body === null) return [];
+  if (typeof body === "string") return body.length ? body.split("\n") : [];
+
+  if (isBodyFromFile(body)) {
+    const b = body as {
+      __bodyFromFile: string;
+      __graphqlVariablesSuffix?: string;
+    };
+    const out = [`< ${maybeQuoteIfHasSpaces(b.__bodyFromFile)}`];
+    if (method === "GRAPHQL" && b.__graphqlVariablesSuffix) {
+      out.push("");
+      out.push(...b.__graphqlVariablesSuffix.trimEnd().split("\n"));
+    }
+    return out;
+  }
+
+  if (method === "GRAPHQL" && isGraphQLBody(body)) {
+    const gql = body as { query: string; variables?: Record<string, unknown> };
+    const out = gql.query.trimEnd().split("\n");
+    if (gql.variables !== undefined) {
+      out.push("");
+      out.push(JSON.stringify(gql.variables, null, 2));
+    }
+    return out;
+  }
+
+  return [JSON.stringify(body, null, 2)];
+}
+
+function serializeBlock(block: KulalaBlock, docFilepath?: string): string[] {
+  const lines: string[] = [];
+  lines.push(`### ${block.name}`.trimEnd());
+  // One blank line after each block separator.
+  lines.push("");
+
+  // Preserve block-local `run ...` directives (the parser stores them on private fields).
+  // If a block contained only a `run` statement, parsing may replace its request/scripts with the referenced block.
+  // To round-trip the *source file*, prefer serializing the run directive instead of the expanded request.
+  const runDirective =
+    (
+      block as unknown as {
+        __runDirective?: KulalaDirective;
+        __blockRunDirective?: KulalaDirective;
+      }
+    ).__runDirective ??
+    (
+      block as unknown as {
+        __runDirective?: KulalaDirective;
+        __blockRunDirective?: KulalaDirective;
+      }
+    ).__blockRunDirective;
+  if (runDirective?.type === "run") {
+    // Keep any preamble/scripts that were authored in this block (they are preserved on the block),
+    // then emit the directive and stop (do not serialize expanded request).
+
+    // Pre-request scripts
+    const preScripts = [...(block.scripts?.preRequest ?? [])].sort(
+      (a, b) => a.lineNumber - b.lineNumber,
+    );
+    pushScriptsWithBlankLines(lines, preScripts, docFilepath);
+    if (preScripts.length > 0) lines.push("");
+
+    // Preamble @vars (no per-line ordering preserved in model)
+    if (block.preambleVariables) {
+      const entries = Object.entries(block.preambleVariables).sort(([a], [b]) =>
+        a.localeCompare(b),
+      );
+      for (const [k, v] of entries) {
+        lines.push(`@${k} = ${v}`);
+      }
+    }
+
+    // Preamble operators/comments in order
+    for (const entry of block.preamble ?? []) {
+      if ("name" in entry) {
+        lines.push(serializeOperator(entry));
+      } else {
+        lines.push(`# ${entry.content}`);
+      }
+    }
+
+    lines.push(serializeDirective(runDirective));
+
+    // Post-request scripts
+    const postScripts = [...(block.scripts?.postRequest ?? [])].sort(
+      (a, b) => a.lineNumber - b.lineNumber,
+    );
+    if (postScripts.length) {
+      lines.push("");
+      pushScriptsWithBlankLines(lines, postScripts, docFilepath);
+    }
+
+    return lines;
+  }
+
+  // Pre-request scripts
+  const preScripts = [...(block.scripts?.preRequest ?? [])].sort(
+    (a, b) => a.lineNumber - b.lineNumber,
+  );
+  pushScriptsWithBlankLines(lines, preScripts, docFilepath);
+  if (preScripts.length > 0) lines.push("");
+
+  // Preamble @vars (no per-line ordering preserved in model)
+  if (block.preambleVariables) {
+    const entries = Object.entries(block.preambleVariables).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    for (const [k, v] of entries) {
+      lines.push(`@${k} = ${v}`);
+    }
+  }
+
+  // Preamble operators/comments in order
+  for (const entry of block.preamble ?? []) {
+    if ("name" in entry) {
+      lines.push(serializeOperator(entry));
+    } else {
+      lines.push(`# ${entry.content}`);
+    }
+  }
+
+  if (block.blankLineBeforeRequest) {
+    lines.push("");
+  }
+
+  // Request line(s)
+  if (block.request.requestLineParts && block.request.requestLineParts.length) {
+    lines.push(
+      ...serializeRequestLineParts(
+        block.request.method,
+        block.request.requestLineParts,
+        block.request.httpVersion,
+      ),
+    );
+  } else {
+    lines.push(
+      `${block.request.method} ${block.request.url}${
+        block.request.httpVersion ? ` ${block.request.httpVersion}` : ""
+      }`.trimEnd(),
+    );
+  }
+
+  // Headers
+  lines.push(...serializeHeaderSection(block.request.headerSection ?? []));
+
+  // Body
+  const bodyLines = serializeBody(block.request.method, block.request.body);
+  const postScripts = [...(block.scripts?.postRequest ?? [])].sort(
+    (a, b) => a.lineNumber - b.lineNumber,
+  );
+  const hasAfterHeaders =
+    bodyLines.length > 0 ||
+    block.request.responseRedirect !== undefined ||
+    postScripts.length > 0;
+  // Only emit the blank line separator when something follows.
+  if (hasAfterHeaders) {
+    lines.push("");
+    lines.push(...bodyLines);
+  }
+
+  // Response redirect
+  if (block.request.responseRedirect) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
+    const rr = block.request.responseRedirect;
+    lines.push(`${rr.overwrite ? ">>!" : ">>"} ${rr.filePath}`.trimEnd());
+  }
+
+  // Post-request scripts
+  if (postScripts.length) {
+    if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
+    pushScriptsWithBlankLines(lines, postScripts, docFilepath);
+  }
+
+  return lines;
+}
+
+export function serializeHttp(
+  doc: KulalaDocument,
+  options: KulalaHttpSerdeSerializeOptions = {},
+): string {
+  const includeExpandedBlocks = options.includeExpandedBlocks === true;
+  const blocks = includeExpandedBlocks
+    ? doc.blocks
+    : doc.blocks.slice(0, doc.nativeBlockCount ?? doc.blocks.length);
+
+  const lines: string[] = [];
+
+  // File header vars
+  if (doc.fileHeaderVariables) {
+    const entries = Object.entries(doc.fileHeaderVariables).sort(([a], [b]) =>
+      a.localeCompare(b),
+    );
+    for (const [k, v] of entries) {
+      lines.push(`@${k} = ${v}`);
+    }
+  }
+
+  // File header operators
+  const fileOps = doc.fileHeaderOperators ?? [];
+  if (fileOps.length) {
+    for (const op of [...fileOps].sort((a, b) => a.lineNumber - b.lineNumber)) {
+      lines.push(serializeOperator(op));
+    }
+  } else if (doc.vscodeRestclientCompat) {
+    lines.push("# @kulala-vscode-restclient-compat");
+  }
+
+  // Directives
+  const directives = doc.directives ?? [];
+  if (directives.length) {
+    for (const d of [...directives].sort((a, b) => a.lineNumber - b.lineNumber))
+      lines.push(serializeDirective(d));
+  }
+
+  if (lines.length) lines.push("");
+
+  // Blocks
+  for (const [i, b] of blocks.entries()) {
+    // One blank line between blocks.
+    if (i > 0) lines.push("");
+    lines.push(...serializeBlock(b, doc.filepath));
+  }
+
+  const out = lines.join("\n").replace(/\s+$/g, "");
+  return out.length ? out + "\n" : "";
+}

--- a/packages/core/src/lib/parser/types/block.ts
+++ b/packages/core/src/lib/parser/types/block.ts
@@ -24,6 +24,8 @@ export type KulalaBlock = {
   contentStartLine?: number;
   /** @name=value lines in this block before the request (JetBrains in-file variables). */
   preambleVariables?: Record<string, string>;
+  /** Empty line between preamble and request line in the source file. */
+  blankLineBeforeRequest?: boolean;
   /** @ variables from the start of the .http file this block was parsed from (imports / run file). */
   sourceFileHeaderVariables?: Record<string, string>;
   /** `# @kulala-vscode-restclient-compat` from the source .http file (imports / run file). */

--- a/packages/core/src/lib/parser/types/comment.ts
+++ b/packages/core/src/lib/parser/types/comment.ts
@@ -3,4 +3,6 @@ export type KulalaCommentString = `# ${string}` | `## ${string}`;
 export type KulalaComment = {
   content: string;
   lineNumber: number;
+  /** Indentation before the `#` / `//` marker (e.g. URL continuation comments). */
+  leadingWhitespace?: string;
 };

--- a/packages/core/src/lib/parser/types/operator.ts
+++ b/packages/core/src/lib/parser/types/operator.ts
@@ -52,4 +52,6 @@ export type KulalaOperator = {
   name: KulalaOperatorName;
   args?: KulalaOperatorArgs;
   lineNumber: number;
+  /** Comment marker used in the source file (`#` or `//`). */
+  commentStyle?: "#" | "//";
 };

--- a/packages/core/src/lib/parser/types/script.ts
+++ b/packages/core/src/lib/parser/types/script.ts
@@ -3,6 +3,8 @@ export type KulalaScriptType = "preRequest" | "postRequest";
 export type KulalaScript = {
   type: KulalaScriptType;
   lang: "ts" | "js" | "lua";
+  /** True when the opening line included `lang=ts|js|lua` (omit on serialize when false). */
+  langExplicit?: boolean;
   /** Inline `{% %} block in HTTP vs external `< path` / `> path`. */
   source: "inline" | "file";
   /** For `file`, path to script relative to cwd; for inline, the enclosing HTTP document path. */


### PR DESCRIPTION
Enables consumers to easilty serialize and deserialize the parser's internal state, which is useful for debugging and testing. This commit also includes a manual inspection script to verify the correctness of the serde implementation.