### PR TITLE
fix(variables): re-expand {{...}} references inside resolved values

### DIFF
--- a/packages/core/src/lib/variables/substitute.ts
+++ b/packages/core/src/lib/variables/substitute.ts
@@ -1,27 +1,31 @@
 import { resolveVariableReference } from "./variable-lookup";
 
 /**
- * Replace {{variableName}} or {{ variableName }} in a string with values from vars.
- * Supports simple names (e.g. API_KEY), JetBrains JSONPath (e.g. CREDENTIALS.password, users[*].name),
- * and compound request vars (e.g. REQUEST_ONE.response.body.$.token).
- * Optional whitespace around the variable name is allowed.
- * Unknown variables are replaced with empty string.
- * If resolver is provided, it is used for missing keys (e.g. request variables).
- *
- * Note: For $auth.token() and $auth.idToken() calls, use substituteInStringAsync instead.
+ * Max iterations for chained-variable expansion (e.g. one env var that
+ * references another). Bounds runtime if values reference each other in a
+ * cycle (`A = "{{B}}"`, `B = "{{A}}"`) or grow without converging
+ * (`A = "x{{A}}"`).
  */
-export function substituteInString(
+const MAX_SUBSTITUTION_DEPTH = 8;
+
+const VAR_RE = /\{\{\s*([^}]+)\s*\}\}/g;
+
+/**
+ * One regex pass: replace every `{{ name }}` in `template` using `vars` and
+ * the optional fallback `resolver`. Auth placeholders are preserved verbatim
+ * so the async path can resolve them.
+ */
+function substituteInStringOnce(
   template: string,
   vars: Record<string, string>,
   resolver?: (name: string) => string | undefined,
 ): string {
-  return template.replace(/\{\{\s*([^}]+)\s*\}\}/g, (_, name) => {
+  return template.replace(VAR_RE, (_, name) => {
     const key = name.trim();
 
-    // Check for $auth.token() or $auth.idToken() syntax - these require async resolution
+    // $auth.token() / $auth.idToken() require async resolution.
     const authMatch = key.match(/^\$auth\.(token|idToken)\s*\(/);
     if (authMatch) {
-      // Keep as-is - caller should use substituteInStringAsync for auth calls
       return `{{${key}}}`;
     }
 
@@ -36,12 +40,41 @@ export function substituteInString(
 }
 
 /**
- * Async version that handles $auth.token() and $auth.idToken() calls.
- * Also supports all regular variable substitution.
+ * Replace {{variableName}} or {{ variableName }} in a string with values from vars.
+ * Supports simple names (e.g. API_KEY), JetBrains JSONPath (e.g. CREDENTIALS.password, users[*].name),
+ * and compound request vars (e.g. REQUEST_ONE.response.body.$.token).
+ * Optional whitespace around the variable name is allowed.
+ * Unknown variables are replaced with empty string.
+ * If resolver is provided, it is used for missing keys (e.g. request variables).
  *
- * This function properly handles multiple occurrences of the same variable.
+ * Values may themselves contain `{{...}}` references; substitution is applied
+ * iteratively until the result stabilises or {@link MAX_SUBSTITUTION_DEPTH}
+ * iterations have run, whichever comes first.
+ *
+ * Note: For $auth.token() and $auth.idToken() calls, use substituteInStringAsync instead.
  */
-export async function substituteInStringAsync(
+export function substituteInString(
+  template: string,
+  vars: Record<string, string>,
+  resolver?: (name: string) => string | undefined,
+): string {
+  let result = template;
+  for (let depth = 0; depth < MAX_SUBSTITUTION_DEPTH; depth++) {
+    const next = substituteInStringOnce(result, vars, resolver);
+    if (next === result) return next;
+    result = next;
+    if (!result.includes("{{")) return result;
+  }
+  return result;
+}
+
+/**
+ * One async pass: regex-walk `template` and produce the next string.
+ * Handles regular vars, fallback resolver, and `$auth.token()`/`$auth.idToken()`
+ * via the optional `authResolver`. Auth placeholders are preserved verbatim
+ * when no `authResolver` is provided.
+ */
+async function substituteInStringOnceAsync(
   template: string,
   vars: Record<string, string>,
   resolver?: (name: string) => string | undefined,
@@ -50,7 +83,7 @@ export async function substituteInStringAsync(
     authId: string,
   ) => Promise<string | undefined>,
 ): Promise<string> {
-  const matches = Array.from(template.matchAll(/\{\{\s*([^}]+)\s*\}\}/g));
+  const matches = Array.from(template.matchAll(VAR_RE));
   let result = template;
 
   // Process matches in reverse order to maintain correct indices when replacing
@@ -93,6 +126,38 @@ export async function substituteInStringAsync(
       result.slice(match.index! + match[0]!.length);
   }
 
+  return result;
+}
+
+/**
+ * Async version that handles $auth.token() and $auth.idToken() calls.
+ * Also supports all regular variable substitution.
+ *
+ * This function properly handles multiple occurrences of the same variable,
+ * and re-expands values that themselves contain `{{...}}` references up to
+ * {@link MAX_SUBSTITUTION_DEPTH} iterations.
+ */
+export async function substituteInStringAsync(
+  template: string,
+  vars: Record<string, string>,
+  resolver?: (name: string) => string | undefined,
+  authResolver?: (
+    func: "token" | "idToken",
+    authId: string,
+  ) => Promise<string | undefined>,
+): Promise<string> {
+  let result = template;
+  for (let depth = 0; depth < MAX_SUBSTITUTION_DEPTH; depth++) {
+    const next = await substituteInStringOnceAsync(
+      result,
+      vars,
+      resolver,
+      authResolver,
+    );
+    if (next === result) return next;
+    result = next;
+    if (!result.includes("{{")) return result;
+  }
   return result;
 }
 

--- a/packages/core/src/lib/variables/variables.test.ts
+++ b/packages/core/src/lib/variables/variables.test.ts
@@ -602,3 +602,113 @@ test("substituteInObjectAsync: resolves $auth.token() in arrays", async () => {
     items: ["Bearer token-123", "other", "Bearer token-123"],
   });
 });
+
+test("substituteInString: re-expands a value that references another var", () => {
+  // Real-world case: an env var whose value composes other env vars,
+  // e.g. http-client.env.json with
+  //   "API": "{{SCHEME}}service.dev.{{API_BASE}}"
+  expect(
+    substituteInString("{{API}}/health", {
+      SCHEME: "https://",
+      API_BASE: "example.com/api",
+      API: "{{SCHEME}}service.dev.{{API_BASE}}",
+    }),
+  ).toBe("https://service.dev.example.com/api/health");
+});
+
+test("substituteInString: chains across multiple levels of indirection", () => {
+  expect(
+    substituteInString("{{A}}", {
+      A: "{{B}}",
+      B: "{{C}}",
+      C: "value",
+    }),
+  ).toBe("value");
+});
+
+test("substituteInString: self-referencing var terminates without infinite loop", () => {
+  // A = "{{A}}" reaches a fixed point on the first pass (the value is
+  // identical to the placeholder), so the loop exits via no-change detection.
+  expect(substituteInString("{{A}}", { A: "{{A}}" })).toBe("{{A}}");
+});
+
+test("substituteInString: mutually-referencing vars terminate via depth cap", () => {
+  // A → B → A → B ... never converges; the depth cap bounds runtime.
+  // The result is one of the two states; the contract is "terminates with
+  // a placeholder", not a specific final string.
+  const result = substituteInString("{{A}}", {
+    A: "{{B}}",
+    B: "{{A}}",
+  });
+  expect(result === "{{A}}" || result === "{{B}}").toBe(true);
+});
+
+test("substituteInString: missing var inside a chained value resolves to empty", () => {
+  expect(
+    substituteInString("[{{A}}]", {
+      A: "x{{MISSING}}y",
+    }),
+  ).toBe("[xy]");
+});
+
+test("substituteInString: chained substitution preserves resolver fallback", () => {
+  const resolver = (name: string) => (name === "PORT" ? "8080" : undefined);
+  expect(
+    substituteInString(
+      "{{URL}}",
+      {
+        URL: "http://localhost:{{PORT}}/api",
+      },
+      resolver,
+    ),
+  ).toBe("http://localhost:8080/api");
+});
+
+test("substituteInStringAsync: re-expands a value that references another var", async () => {
+  const result = await substituteInStringAsync("{{API}}/health", {
+    SCHEME: "https://",
+    API_BASE: "example.com/api",
+    API: "{{SCHEME}}service.dev.{{API_BASE}}",
+  });
+  expect(result).toBe("https://service.dev.example.com/api/health");
+});
+
+test("substituteInStringAsync: chained value mixed with $auth.token()", async () => {
+  const authResolver = async (
+    func: "token" | "idToken",
+    authId: string,
+  ): Promise<string | undefined> => {
+    if (func === "token" && authId === "my-auth") return "tok";
+    return undefined;
+  };
+  const result = await substituteInStringAsync(
+    "{{AUTHED_URL}}",
+    {
+      BASE: "https://api.example.com",
+      AUTHED_URL: '{{BASE}}?token={{$auth.token("my-auth")}}',
+    },
+    undefined,
+    authResolver,
+  );
+  expect(result).toBe("https://api.example.com?token=tok");
+});
+
+test("substituteInStringAsync: self-referencing var terminates without infinite loop", async () => {
+  const result = await substituteInStringAsync("{{A}}", { A: "{{A}}" });
+  expect(result).toBe("{{A}}");
+});
+
+test("substituteInObject: chained env vars expand inside nested object values", () => {
+  const out = substituteInObject(
+    { url: "{{API}}/x", body: { ref: "{{API}}" } },
+    {
+      SCHEME: "https://",
+      HOST: "example.com",
+      API: "{{SCHEME}}{{HOST}}",
+    },
+  );
+  expect(out).toEqual({
+    url: "https://example.com/x",
+    body: { ref: "https://example.com" },
+  });
+});


### PR DESCRIPTION
Happy to receive any/all feedback on implementation or style here, I virtually never work with typescript.


Variables that compose other variables were left with their inner placeholders unresolved, because substituteInString and substituteInStringAsync ran a single regex pass over the template and never re-processed the replaced values. Both sync and async substitute functions now iterate up to a fixed depth (8), exiting early on no-change or when no {{...}} markers remain. 

This behavior is documented as possible [here](https://neovim.getkulala.net/docs/usage/dotenv-and-http-client.env.json-support#kulalashared-shared-variables-and-default-headers), but is currently non-functional. (kulala.nvim v6.7.0)

Example:
http-client.env.json
```
{
  "$schema": "https://getkulala.net/http-client.env.schema.json",
  "$kulalaShared": {
    "SCHEME": "https://",
    "API_BASE": "example.com/api",
  },
  "dev": {
    "API": "{{SCHEME}}service.dev.{{API_BASE}}"
  }
}
```

requests.http
```
GET {{API}/endpoint HTTP/1.1
```

Now resolves to `https://service.dev.example.com/api/endpoint` instead of `{{SCHEME}}service.dev.{{API_BASE}}/endpoint` as is current behavior.