### PR TITLE
feat(oauth2): add variable substitution support to OAuth2Manager

### DIFF
--- a/packages/core/src/lib/auth/oauth2/manager.ts
+++ b/packages/core/src/lib/auth/oauth2/manager.ts
@@ -3,6 +3,7 @@ import {
   loadOAuth2AuthData,
   saveOAuth2AuthData,
 } from "./config";
+import { substituteInString } from "../../variables/substitute";
 import {
   acquireAuthorizationCodeToken,
   acquireClientCredentialsToken,
@@ -14,6 +15,26 @@ import {
 import type { OAuth2Config, OAuth2TokenData } from "./types";
 import { OAuth2PromptError } from "./prompt-error";
 
+function substituteConfigValue(
+  value: unknown,
+  vars: Record<string, string>,
+): unknown {
+  if (typeof value === "string") {
+    return substituteInString(value, vars);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => substituteConfigValue(item, vars));
+  }
+  if (typeof value === "object" && value !== null) {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = substituteConfigValue(item, vars);
+    }
+    return out;
+  }
+  return value;
+}
+
 /**
  * OAuth2 token manager. Handles token acquisition, refresh, and storage.
  */
@@ -22,16 +43,30 @@ export class OAuth2Manager {
   private tokens: Map<string, OAuth2TokenData> = new Map();
   private env: string;
   private startDir: string;
+  private substitutionVars: Record<string, string>;
 
-  constructor(env: string, startDir: string) {
+  constructor(
+    env: string,
+    startDir: string,
+    substitutionVars: Record<string, string>,
+  ) {
     this.env = env;
     this.startDir = startDir;
+    this.substitutionVars = substitutionVars;
     this.loadConfigs();
     this.loadTokens();
   }
 
   private loadConfigs(): void {
-    this.configs = loadOAuth2Configs(this.env, this.startDir);
+    this.configs = new Map(
+      Array.from(
+        loadOAuth2Configs(this.env, this.startDir),
+        ([authId, config]) => [
+          authId,
+          substituteConfigValue(config, this.substitutionVars) as OAuth2Config,
+        ],
+      ),
+    );
   }
 
   private loadTokens(): void {

--- a/packages/core/src/lib/auth/oauth2/oauth2.test.ts
+++ b/packages/core/src/lib/auth/oauth2/oauth2.test.ts
@@ -153,7 +153,7 @@ test("OAuth2: Manager loads config and acquires token", async () => {
     ),
   );
 
-  const manager = new OAuth2Manager("default", testDir);
+  const manager = new OAuth2Manager("default", testDir, {});
   const token = await manager.getAccessToken("test-auth");
   expect(token).toBe("test-access-token-123");
 
@@ -166,6 +166,44 @@ test("OAuth2: Manager loads config and acquires token", async () => {
   expect(privateData.default.auth_data["test-auth"].access_token).toBe(
     "test-access-token-123",
   );
+});
+
+test("OAuth2: Manager substitutes variables in loaded config", async () => {
+  const envFile = join(testDir, "http-client.env.json");
+  writeFileSync(
+    envFile,
+    JSON.stringify(
+      {
+        default: {
+          OAUTH_TOKEN_URL: tokenUrl,
+          OAUTH_CLIENT_ID: "test-client-id",
+          OAUTH_CLIENT_SECRET: "test-client-secret",
+          Security: {
+            Auth: {
+              "test-auth-vars": {
+                Type: "OAuth2",
+                "Grant Type": "Client Credentials",
+                "Token URL": "{{OAUTH_TOKEN_URL}}",
+                "Client ID": "{{OAUTH_CLIENT_ID}}",
+                "Client Secret": "{{OAUTH_CLIENT_SECRET}}",
+                "Client Credentials": "basic",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const manager = new OAuth2Manager("default", testDir, {
+    OAUTH_TOKEN_URL: tokenUrl,
+    OAUTH_CLIENT_ID: "test-client-id",
+    OAUTH_CLIENT_SECRET: "test-client-secret",
+  });
+  const token = await manager.getAccessToken("test-auth-vars");
+  expect(token).toBe("test-access-token-123");
 });
 
 test("OAuth2: Manager reuses valid token", async () => {
@@ -216,7 +254,7 @@ test("OAuth2: Manager reuses valid token", async () => {
     ),
   );
 
-  const manager = new OAuth2Manager("default", testDir);
+  const manager = new OAuth2Manager("default", testDir, {});
   const token = await manager.getAccessToken("test-auth-2");
   // Should use cached token, not make a new request
   expect(token).toBe("cached-token-456");
@@ -278,7 +316,7 @@ test("OAuth2: Manager handles Password grant type", async () => {
     ),
   );
 
-  const manager = new OAuth2Manager("default", testDir);
+  const manager = new OAuth2Manager("default", testDir, {});
   const token = await manager.getAccessToken("test-password-auth");
   expect(token).toBe("password-token-789");
 
@@ -309,7 +347,7 @@ test("OAuth2: Manager throws error for unsupported grant type", async () => {
     ),
   );
 
-  const manager = new OAuth2Manager("default", testDir);
+  const manager = new OAuth2Manager("default", testDir, {});
   await expect(manager.getAccessToken("test-device-auth")).rejects.toThrow(
     "Device Authorization",
   );

--- a/packages/core/src/lib/runner/doRequest.ts
+++ b/packages/core/src/lib/runner/doRequest.ts
@@ -339,11 +339,15 @@ export async function doRequestFromBlock(
     return { varName, label };
   };
 
+  // Pre-request scripts may set variables that affect substitution.
+  // Keep `vars` mutable within this block.
+  const mutableVars = vars ?? {};
+
   // Initialize OAuth2 manager if needed
   const startDir = filePath
     ? (await import("path")).dirname(filePath)
     : process.cwd();
-  const oauth2Manager = new OAuth2Manager(env, startDir);
+  const oauth2Manager = new OAuth2Manager(env, startDir, mutableVars);
   const authResolver = async (
     func: "token" | "idToken",
     authId: string,
@@ -354,10 +358,6 @@ export async function doRequestFromBlock(
       return await oauth2Manager.getIdToken(authId);
     }
   };
-
-  // Pre-request scripts may set variables that affect substitution.
-  // Keep `vars` mutable within this block.
-  const mutableVars = vars ?? {};
 
   const stableDocId = stableDocIdForReplay ?? filePath ?? "";
   const effectiveOperators = getEffectiveOperators(

--- a/packages/core/src/lib/runner/resolve-request-from-block.ts
+++ b/packages/core/src/lib/runner/resolve-request-from-block.ts
@@ -105,7 +105,7 @@ export async function resolveRequestFromBlock(
       .map((o) => String(o.args ?? ""))
       .find((s) => s.trim() !== "");
   const hasOp = (names: string[]): boolean => getOps(names).length > 0;
-  const oauth2Manager = new OAuth2Manager(env, startDir);
+  const oauth2Manager = new OAuth2Manager(env, startDir, mutableVars);
   const authResolver = async (
     func: "token" | "idToken",
     authId: string,


### PR DESCRIPTION
After the switch to kulala-core, there is now a regression in kulala.nvim: variable expansion/substitution in the authentication configuration doesn't work anymore (see https://github.com/mistweaverco/kulala.nvim/issues/619).
This PR adds back this feature and restores compatibility with IntelliJ and VSCode (httpYac).