### PR TITLE
fix(oauth2): use client secret from private env file

### DIFF
--- a/http-example-files/http-client.env.json
+++ b/http-example-files/http-client.env.json
@@ -15,6 +15,19 @@
     },
     "websocket": {
       "addr": "wss://ws.ifelse.io"
+    },
+    "Security": {
+      "Auth": {
+        "default-mock-name": {
+          "Type": "OAuth2",
+          "Grant Type": "Authorization Code",
+          "Redirect URL": "https://httpbun.com/get",
+          "Client ID": "kulala-core",
+          "Client Credentials": "in body",
+          "Auth URL": "https://httpbun.com/oauth2/authorize",
+          "Token URL": "https://httpbun.com/oauth2/token"
+        }
+      }
     }
   },
   "dev": {

--- a/http-example-files/oauth2.http
+++ b/http-example-files/oauth2.http
@@ -1,9 +1,9 @@
-### GET_DATA_WITH_SCOPES
+### get-data-with-scopes
 
 # Step 3: Use Refresh Token (automatic)
 # If the access token expires, Kulala will automatically refresh it
 # using the refresh_token (if available) before making this request
 
-POST https://echo.kulala.app/post HTTP/1.1
+GET https://echo.kulala.app/get HTTP/1.1
 Accept: application/json
-Authorization: Bearer {{ $auth.token("playground-oauth2") }}
+Authorization: Bearer {{ $auth.token("default-mock-name") }}

--- a/packages/core/src/lib/auth/oauth2/browser-flow.test.ts
+++ b/packages/core/src/lib/auth/oauth2/browser-flow.test.ts
@@ -11,6 +11,7 @@ import {
   generatePKCE,
   generatePKCEPlain,
   isLocalhostRedirect,
+  parseRedirectInput,
   startRedirectServer,
 } from "./browser-flow";
 import type { OAuth2Config } from "./types";
@@ -303,6 +304,30 @@ test("OAuth2: PKCE generation", async () => {
   expect(pkcePlain.challenge).toBeDefined();
   expect(pkcePlain.method).toBe("Plain");
   expect(pkcePlain.challenge).toBe(pkcePlain.verifier); // Plain should be same
+});
+
+test("OAuth2: parseRedirectInput accepts bare authorization codes", () => {
+  expect(parseRedirectInput("abc123plain", "Authorization Code")).toEqual({
+    code: "abc123plain",
+  });
+  expect(parseRedirectInput("1.AXkAtestcode", "Authorization Code")).toEqual({
+    code: "1.AXkAtestcode",
+  });
+  expect(parseRedirectInput("M.R3_BAY.c0xxx==", "Authorization Code")).toEqual({
+    code: "M.R3_BAY.c0xxx==",
+  });
+  expect(parseRedirectInput("code=abc123", "Authorization Code")).toEqual({
+    code: "abc123",
+  });
+  expect(
+    parseRedirectInput(
+      "http://localhost:8081/?code=abc123",
+      "Authorization Code",
+    ),
+  ).toEqual({ code: "abc123" });
+  expect(
+    parseRedirectInput("localhost:8081/?code=abc123", "Authorization Code"),
+  ).toEqual({ code: "abc123" });
 });
 
 test("OAuth2: isLocalhostRedirect detects localhost URLs", () => {

--- a/packages/core/src/lib/auth/oauth2/browser-flow.ts
+++ b/packages/core/src/lib/auth/oauth2/browser-flow.ts
@@ -154,14 +154,12 @@ export function parseRedirectInput(
   }
 
   if (grantType === "Authorization Code") {
-    if (!code) {
-      // If we couldn't parse as URL and user just pasted the code, we already returned it above
-      // This shouldn't happen, but handle it gracefully
-      throw new Error(
-        "No authorization code found. Please paste the full redirect URL (including ?code=...) or just the authorization code.",
-      );
+    if (code) {
+      return { code };
     }
-    return { code };
+    // Providers (e.g. Microsoft Entra) may issue codes containing '='. When URL
+    // parsing did not yield ?code=, treat the whole pasted value as the code.
+    return { code: trimmed };
   } else {
     // Implicit grant
     if (!access_token) {

--- a/packages/core/src/lib/auth/oauth2/config.ts
+++ b/packages/core/src/lib/auth/oauth2/config.ts
@@ -37,7 +37,11 @@ export function loadOAuth2Configs(
                 config !== null &&
                 (config as { Type?: unknown }).Type === "OAuth2"
               ) {
-                configs.set(authId, config as OAuth2Config);
+                const existing = configs.get(authId);
+                configs.set(authId, {
+                  ...existing,
+                  ...(config as OAuth2Config),
+                } as OAuth2Config);
               }
             }
           }
@@ -57,17 +61,19 @@ export function loadOAuth2Configs(
           const auth = (security as Record<string, unknown>).Auth;
           if (typeof auth === "object" && auth !== null) {
             for (const [authId, config] of Object.entries(auth)) {
-              if (
-                typeof config === "object" &&
-                config !== null &&
-                (config as { Type?: unknown }).Type === "OAuth2"
-              ) {
-                // Merge with existing config (private overrides)
-                const existing = configs.get(authId);
-                configs.set(authId, {
-                  ...existing,
-                  ...(config as OAuth2Config),
-                } as OAuth2Config);
+              if (typeof config === "object" && config !== null) {
+                const isOAuth2Entry =
+                  (config as { Type?: unknown }).Type === "OAuth2";
+                const hasExistingOAuth2 = configs.has(authId);
+                // Merge partial private overrides (e.g. Client Secret only) into
+                // the public OAuth2 config, or full private OAuth2 entries.
+                if (isOAuth2Entry || hasExistingOAuth2) {
+                  const existing = configs.get(authId);
+                  configs.set(authId, {
+                    ...existing,
+                    ...(config as OAuth2Config),
+                  } as OAuth2Config);
+                }
               }
             }
           }

--- a/packages/core/src/lib/auth/oauth2/continuation.ts
+++ b/packages/core/src/lib/auth/oauth2/continuation.ts
@@ -3,6 +3,8 @@ import { getPrompt, deletePrompt } from "../../persistence";
 import { exchangeAuthorizationCode } from "./acquisition";
 import { parseRedirectInput } from "./browser-flow";
 import { saveOAuth2AuthData } from "./config";
+import { resolveOAuth2Config } from "./manager";
+import { loadEnvVars } from "../../variables/env-files";
 
 /**
  * Continue OAuth2 flow from a prompt.
@@ -27,10 +29,13 @@ export async function continueOAuth2Flow(
   }
 
   const context = prompt.context;
-  const config = context.config as OAuth2Config;
   const authId = context.authId as string;
   const env = context.env as string;
   const startDir = context.startDir as string;
+  const envVars = loadEnvVars(env, startDir);
+  const config =
+    resolveOAuth2Config(authId, env, startDir, envVars) ??
+    (context.config as OAuth2Config);
   const grantType = config["Grant Type"];
 
   // Convert array of inputs to a map for easier lookup

--- a/packages/core/src/lib/auth/oauth2/manager.ts
+++ b/packages/core/src/lib/auth/oauth2/manager.ts
@@ -35,6 +35,52 @@ function substituteConfigValue(
   return value;
 }
 
+/** OAuth2 auth fields that may live only in http-client.private.env.json. */
+const PRIVATE_OVERRIDE_FIELDS = [
+  "Client Secret",
+  "Password",
+  "Assertion",
+] as const;
+
+/**
+ * Fill OAuth2 secrets from flattened env vars (same paths as loadEnvVars).
+ * Matches kulala.nvim env merging when private overrides omit `"Type": "OAuth2"`.
+ */
+function enrichOAuth2ConfigFromEnvVars(
+  authId: string,
+  config: OAuth2Config,
+  vars: Record<string, string>,
+): OAuth2Config {
+  const enriched = { ...config };
+  for (const field of PRIVATE_OVERRIDE_FIELDS) {
+    const current = enriched[field];
+    if (typeof current === "string" && current.length > 0) continue;
+    const fromVars = vars[`Security.Auth.${authId}.${field}`];
+    if (fromVars) {
+      enriched[field] = fromVars;
+    }
+  }
+  return enriched;
+}
+
+/**
+ * Load, substitute, and enrich one OAuth2 config entry.
+ */
+export function resolveOAuth2Config(
+  authId: string,
+  env: string,
+  startDir: string,
+  substitutionVars: Record<string, string>,
+): OAuth2Config | undefined {
+  const raw = loadOAuth2Configs(env, startDir).get(authId);
+  if (!raw) return undefined;
+  const substituted = substituteConfigValue(
+    raw,
+    substitutionVars,
+  ) as OAuth2Config;
+  return enrichOAuth2ConfigFromEnvVars(authId, substituted, substitutionVars);
+}
+
 /**
  * OAuth2 token manager. Handles token acquisition, refresh, and storage.
  */
@@ -58,15 +104,24 @@ export class OAuth2Manager {
   }
 
   private loadConfigs(): void {
-    this.configs = new Map(
-      Array.from(
-        loadOAuth2Configs(this.env, this.startDir),
-        ([authId, config]) => [
+    this.configs = new Map();
+    const rawConfigs = loadOAuth2Configs(this.env, this.startDir);
+    for (const authId of rawConfigs.keys()) {
+      const raw = rawConfigs.get(authId);
+      if (!raw) continue;
+      const substituted = substituteConfigValue(
+        raw,
+        this.substitutionVars,
+      ) as OAuth2Config;
+      this.configs.set(
+        authId,
+        enrichOAuth2ConfigFromEnvVars(
           authId,
-          substituteConfigValue(config, this.substitutionVars) as OAuth2Config,
-        ],
-      ),
-    );
+          substituted,
+          this.substitutionVars,
+        ),
+      );
+    }
   }
 
   private loadTokens(): void {

--- a/packages/core/src/lib/auth/oauth2/oauth2.test.ts
+++ b/packages/core/src/lib/auth/oauth2/oauth2.test.ts
@@ -1,8 +1,13 @@
 import { expect, test, beforeAll, afterAll } from "bun:test";
 import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
-import { OAuth2Manager } from "./manager";
-import { acquireClientCredentialsToken } from "./acquisition";
+import { OAuth2Manager, resolveOAuth2Config } from "./manager";
+import { loadOAuth2Configs } from "./config";
+import {
+  acquireClientCredentialsToken,
+  exchangeAuthorizationCode,
+} from "./acquisition";
+import { loadEnvVars } from "../../variables/env-files";
 import { generatePKCE, generatePKCEPlain } from "./browser-flow";
 import type { OAuth2Config } from "./types";
 
@@ -124,6 +129,245 @@ test("OAuth2: Client Credentials with credentials in body", async () => {
 
   const tokenData = await acquireClientCredentialsToken(config);
   expect(tokenData.access_token).toBe("test-access-token-123");
+});
+
+test("OAuth2: loadOAuth2Configs merges secret-only private override", () => {
+  const envFile = join(testDir, "http-client.env.json");
+  const privateFile = join(testDir, "http-client.private.env.json");
+  writeFileSync(
+    envFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                Type: "OAuth2",
+                "Grant Type": "Authorization Code",
+                "Token URL": tokenUrl,
+                "Client ID": "test-client-id",
+                "Client Credentials": "in body",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    privateFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                "Client Secret": "test-client-secret",
+              },
+            },
+          },
+          auth_data: {},
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const configs = loadOAuth2Configs("dev", testDir);
+  const config = configs.get("entra-code");
+  expect(config).toBeDefined();
+  expect(config?.Type).toBe("OAuth2");
+  expect(config?.["Client ID"]).toBe("test-client-id");
+  expect(config?.["Client Secret"]).toBe("test-client-secret");
+});
+
+test("OAuth2: resolveOAuth2Config picks up secret from flattened env vars", () => {
+  const envFile = join(testDir, "http-client.env.json");
+  const privateFile = join(testDir, "http-client.private.env.json");
+  writeFileSync(
+    envFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                Type: "OAuth2",
+                "Grant Type": "Client Credentials",
+                "Token URL": tokenUrl,
+                "Client ID": "test-client-id",
+                "Client Credentials": "in body",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    privateFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                "Client Secret": "test-client-secret",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const vars = loadEnvVars("dev", testDir);
+  const config = resolveOAuth2Config("entra-code", "dev", testDir, vars);
+  expect(config?.["Client Secret"]).toBe("test-client-secret");
+});
+
+test("OAuth2: Manager acquires token with secret-only private override", async () => {
+  const envFile = join(testDir, "http-client.env.json");
+  const privateFile = join(testDir, "http-client.private.env.json");
+  writeFileSync(
+    envFile,
+    JSON.stringify(
+      {
+        default: {
+          Security: {
+            Auth: {
+              "split-secret-auth": {
+                Type: "OAuth2",
+                "Grant Type": "Client Credentials",
+                "Token URL": tokenUrl,
+                "Client ID": "test-client-id",
+                "Client Credentials": "in body",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    privateFile,
+    JSON.stringify(
+      {
+        default: {
+          Security: {
+            Auth: {
+              "split-secret-auth": {
+                "Client Secret": "test-client-secret",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const vars = loadEnvVars("default", testDir);
+  const manager = new OAuth2Manager("default", testDir, vars);
+  const token = await manager.getAccessToken("split-secret-auth");
+  expect(token).toBe("test-access-token-123");
+});
+
+test("OAuth2: exchangeAuthorizationCode sends client_secret from resolved config", async () => {
+  const authCodeServer = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/auth-code-token" && req.method === "POST") {
+        const body = await req.text();
+        const params = new URLSearchParams(body);
+        if (
+          params.get("grant_type") === "authorization_code" &&
+          params.get("code") === "test-code" &&
+          params.get("client_id") === "test-client-id" &&
+          params.get("client_secret") === "test-client-secret"
+        ) {
+          return Response.json({
+            access_token: "auth-code-token",
+            token_type: "Bearer",
+            expires_in: 3600,
+          });
+        }
+        return new Response(
+          JSON.stringify({
+            error: "invalid_request",
+            error_description: "Missing required parameter: client_secret",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("Not Found", { status: 404 });
+    },
+  });
+
+  const authCodeTokenUrl = `http://localhost:${authCodeServer.port}/auth-code-token`;
+  const envFile = join(testDir, "http-client.env.json");
+  const privateFile = join(testDir, "http-client.private.env.json");
+  writeFileSync(
+    envFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                Type: "OAuth2",
+                "Grant Type": "Authorization Code",
+                "Token URL": authCodeTokenUrl,
+                "Client ID": "test-client-id",
+                "Redirect URL": "http://localhost:8081/",
+                "Client Credentials": "in body",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(
+    privateFile,
+    JSON.stringify(
+      {
+        dev: {
+          Security: {
+            Auth: {
+              "entra-code": {
+                "Client Secret": "test-client-secret",
+              },
+            },
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const vars = loadEnvVars("dev", testDir);
+  const config = resolveOAuth2Config("entra-code", "dev", testDir, vars);
+  expect(config?.["Client Secret"]).toBe("test-client-secret");
+
+  const tokenData = await exchangeAuthorizationCode(config!, "test-code");
+  expect(tokenData.access_token).toBe("auth-code-token");
+
+  authCodeServer.stop();
 });
 
 test("OAuth2: Manager loads config and acquires token", async () => {


### PR DESCRIPTION
Even though Jetbrains http client errors when "Client Secret" is missing in the public `http-client.env.json` file, I consider this a bug and therefore we break compat here.