### PR TITLE
Encode URL before passing it to curl

### DIFF
--- a/packages/core/src/lib/runner/curl-transport.ts
+++ b/packages/core/src/lib/runner/curl-transport.ts
@@ -359,7 +359,7 @@ export async function curlHttpRequest(
       args.push("--data-binary", `@${uploadPath}`);
     }
 
-    args.push(currentUrl);
+    args.push(decodeURI(encodeURI(currentUrl)));
 
     try {
       const { stdout, stderr, exitCode } = await runCurl(args);


### PR DESCRIPTION
This fixes requests with spaces in the URL or with other special characters that need to be encoded.