### PR TITLE
fix(parser): use @name directive as block/symbol name when available

### DIFF
--- a/packages/core/src/lib/lsp/lsp.test.ts
+++ b/packages/core/src/lib/lsp/lsp.test.ts
@@ -73,6 +73,29 @@ GET https://example.com HTTP/1.1
   expect(syms[1]!.name).toBe("Two");
 });
 
+test("lspDocumentSymbols uses @name directive over generated name", async () => {
+  const content = `###
+# @name GET example from name
+GET https://example.com HTTP/1.1
+
+### GET example from header
+GET https://example.com HTTP/1.1
+
+### GET example from header (misc)
+# @name GET example from name (misc)
+GET https://example.com HTTP/1.1
+
+###
+GET https://example.com HTTP/1.1
+`;
+  const syms = await lspDocumentSymbols({ content, filepath: "/tmp/sym.http" });
+  expect(syms).toHaveLength(4);
+  expect(syms[0]!.name).toBe("GET example from name");
+  expect(syms[1]!.name).toBe("GET example from header");
+  expect(syms[2]!.name).toBe("GET example from name (misc)");
+  expect(syms[3]!.name).toBe("REQUEST_004");
+});
+
 test("lspHover returns plaintext when no request at cursor", async () => {
   const content = `just some text
 still not a request`;

--- a/packages/core/src/lib/parser/parser.ts
+++ b/packages/core/src/lib/parser/parser.ts
@@ -51,7 +51,7 @@ type BlockWithRunDirective = KulalaBlock & {
   __runDirectiveLine?: number;
 };
 
-const getBlockName = (rawBlock: string, idx: number): string => {
+const getBlockDefaultName = (rawBlock: string, idx: number): string => {
   return rawBlock.match(nameRegex)?.[1] || `REQUEST_${pad(idx + 1, 3, "0")}`;
 };
 
@@ -168,7 +168,7 @@ const getParsedBlock = async (
     KulalaBlockLineType["name"]
   >();
   const lines = rawBlock.split("\n");
-  const name = getBlockName(rawBlock, idx);
+  const name = getBlockDefaultName(rawBlock, idx);
   const result: KulalaBlock = {
     name,
     errors: [],
@@ -277,6 +277,9 @@ const getParsedBlock = async (
         }
         result.preamble.push(operator);
         result.operators.push(operator);
+        if (operator.name === "name" && operator.args) {
+          result.name = String(operator.args);
+        }
         break;
       case "body":
         if (result.request.body) break;


### PR DESCRIPTION
Closes #146 

This PR make the name of the request take into account the `@name` directive.

I renamed the `getBlockName` method to `getBlockDefaultName` so future developers can know that this name may be overwritten somewhere else later.

Let me know if I should fix or improve anything. 