### PR TITLE
fix(requests): request operators should have precedence

### DIFF
--- a/http-example-files/load-test/load-test.http.js
+++ b/http-example-files/load-test/load-test.http.js
@@ -1,0 +1,40 @@
+const ITERATIONS = 10;
+const RESPONSE_TIMES = new Map();
+const REQUEST_ORDER = [];
+const EXPECTED_STATUS = 200;
+const START_TIME = Date.now();
+
+const PROMISES = Array.from({ length: ITERATIONS }, (_, i) =>
+  (async () => {
+    const start = Date.now();
+    const response = await $kulala.runRequest(
+      "load-test-template",
+      "./request-template.http",
+    );
+    const end = Date.now();
+    RESPONSE_TIMES.set(i + 1, end - start);
+    REQUEST_ORDER.push(i + 1);
+    client.assert(
+      response.status === EXPECTED_STATUS,
+      response.status === EXPECTED_STATUS
+        ? `Iteration ${i + 1}: Status is ${EXPECTED_STATUS}`
+        : `Iteration ${i + 1}: Expected status ${EXPECTED_STATUS} but got ${response.status}`,
+    );
+    return response;
+  })(),
+);
+
+await Promise.all(PROMISES);
+
+const END_TIME = Date.now();
+const DURATION = END_TIME - START_TIME;
+
+client.log(`Completed ${ITERATIONS} iterations in ${DURATION} ms`);
+client.log(
+  `Average response time: ${[...RESPONSE_TIMES.values()].reduce((a, b) => a + b, 0) / RESPONSE_TIMES.size} ms`,
+);
+client.log(`Longest response time: ${Math.max(...RESPONSE_TIMES.values())} ms`);
+client.log(
+  `Shortest response time: ${Math.min(...RESPONSE_TIMES.values())} ms`,
+);
+client.log(`Request order: ${REQUEST_ORDER.join(", ")}`);

--- a/http-example-files/load-test/request-template.http
+++ b/http-example-files/load-test/request-template.http
@@ -1,0 +1,6 @@
+### load-test-template
+
+# @timeout 300 ms
+
+GET https://echo.kulala.app/get HTTP/1.1
+Content-Type: application/json

--- a/http-example-files/load-test/run.http
+++ b/http-example-files/load-test/run.http
@@ -1,0 +1,6 @@
+### rur
+
+GET https://echo.kulala.app/get HTTP/1.1
+Content-Type: application/json
+
+> ./load-test.http.js

--- a/packages/core/src/lib/runner/doRequest.test.ts
+++ b/packages/core/src/lib/runner/doRequest.test.ts
@@ -732,6 +732,77 @@ test("doRequestFromBlock: # @timeout triggers a timeout against a slow endpoint"
   expect(result.success).toBe(false);
 });
 
+test("doRequestFromBlock: # @timeout overrides default --max-time", async () => {
+  const { mkdtempSync, writeFileSync } = await import("fs");
+  const { join } = await import("path");
+  const { tmpdir } = await import("os");
+
+  const dir = mkdtempSync(join(tmpdir(), "kulala-timeout-"));
+  const httpClientEnvPath = join(dir, "http-client.env.json");
+
+  // Default curl options apply when `doRequestFromBlock` receives a `filePath`
+  // and searches upward from that directory.
+  writeFileSync(
+    httpClientEnvPath,
+    JSON.stringify(
+      {
+        $kulalaShared: {
+          $kulalaDefaultCurlOptions: ["--max-time 2"],
+        },
+        default: { env_name: "default" },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+
+  const filePath = join(dir, "example.http");
+
+  const slowServer = Bun.serve({
+    port: 0,
+    async fetch() {
+      await new Promise((r) => setTimeout(r, 100));
+      return new Response("ok", { headers: { "Content-Type": "text/plain" } });
+    },
+  });
+
+  if (slowServer.port === undefined) {
+    throw new Error("Slow server did not expose a listening port");
+  }
+
+  const slowUrl = `http://localhost:${slowServer.port}/slow`;
+
+  const block = makeBlock({
+    operators: [
+      {
+        name: "timeout",
+        args: "50 ms", // should override default --max-time 2 and therefore timeout
+        lineNumber: 1,
+      } as KulalaOperator,
+    ],
+    request: {
+      method: "GET",
+      url: slowUrl as KulalaHttpURL,
+      headerSection: [],
+    },
+  });
+
+  const result = await httpDoRequestFromBlock(
+    block,
+    filePath,
+    undefined,
+    "stable-doc",
+    undefined,
+    "default",
+    { globalHeaders: {} },
+  );
+
+  slowServer.stop();
+
+  expect(result.success).toBe(false);
+});
+
 test("doRequestFromBlock: # @timeout 5 s uses seconds for curl (not milliseconds)", async () => {
   const slowServer = Bun.serve({
     port: 0,

--- a/packages/core/src/lib/runner/doRequest.ts
+++ b/packages/core/src/lib/runner/doRequest.ts
@@ -332,19 +332,6 @@ export async function doRequestFromBlock(
 ): Promise<DoRequestFromBlockResult | DoRequestFromBlockResult[]> {
   const scriptConsole: KulalaScriptConsoleLine[] = [];
 
-  const parseDurationToSec = (raw: string): number | undefined => {
-    const s = raw.trim();
-    if (!s) return undefined;
-    const m = s.match(/^(\d+(?:\.\d+)?)\s*(ms|s|m)?$/i);
-    if (!m) return undefined;
-    const n = Number(m[1]);
-    if (!Number.isFinite(n) || n < 0) return undefined;
-    const unit = (m[2] ?? "s").toLowerCase();
-    if (unit === "ms") return n / 1000;
-    if (unit === "m") return n * 60;
-    return n;
-  };
-
   const parsePromptArgs = parseKulalaPromptOperatorArgs;
 
   // Pre-request scripts may set variables that affect substitution.
@@ -961,15 +948,6 @@ export async function doRequestFromBlock(
 
     const method = (isGraphQL ? "POST" : block.request.method) || "GET";
 
-    const timeoutSecJetBrains = parseDurationToSec(
-      getOpArgs(["timeout"]) ?? "",
-    );
-    const connectionTimeoutSecJetBrains = parseDurationToSec(
-      getOpArgs(["connection-timeout"]) ?? "",
-    );
-    const effectiveTimeoutSec = timeoutSecJetBrains ?? undefined;
-    const effectiveConnectionTimeoutSec =
-      connectionTimeoutSecJetBrains ?? undefined;
     const followRedirects = !hasOp(["no-redirect"]);
 
     try {
@@ -1031,8 +1009,6 @@ export async function doRequestFromBlock(
         headers: requestHeaders,
         body: bodyPayload,
         httpVersion: block.request.httpVersion,
-        timeoutSec: effectiveTimeoutSec,
-        connectionTimeoutSec: effectiveConnectionTimeoutSec,
         followRedirects,
         propagateCookiesOnRedirect: cookieJarEnabled,
         cookieJarEnabled,

--- a/packages/core/src/lib/runner/effective-operators.test.ts
+++ b/packages/core/src/lib/runner/effective-operators.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import type { KulalaDocument } from "../parser/types";
 import type { KulalaBlock } from "../parser/types/block";
-import { getEffectiveJqFilter } from "./effective-operators";
+import type { KulalaOperator } from "../parser/types/operator";
+import {
+  getEffectiveCurlArgv,
+  getEffectiveJqFilter,
+  jetbrainsOperatorsToCurlArgv,
+  parseDurationToSec,
+} from "./effective-operators";
 
 function block(operators: KulalaBlock["operators"]): KulalaBlock {
   return {
@@ -11,6 +20,93 @@ function block(operators: KulalaBlock["operators"]): KulalaBlock {
     scripts: { preRequest: [], postRequest: [] },
   } as unknown as KulalaBlock;
 }
+
+function op(name: KulalaOperator["name"], args?: string): KulalaOperator {
+  return { name, args, lineNumber: 0 };
+}
+
+function envDirWithDefaults(defaults: string[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "kulala-curl-ops-"));
+  writeFileSync(
+    join(dir, "http-client.env.json"),
+    JSON.stringify({
+      $kulalaShared: { $kulalaDefaultCurlOptions: defaults },
+      default: { env_name: "default" },
+    }),
+    "utf-8",
+  );
+  return dir;
+}
+
+describe("parseDurationToSec", () => {
+  test("parses ms, s, and m units", () => {
+    expect(parseDurationToSec("10 ms")).toBe(0.01);
+    expect(parseDurationToSec("5 s")).toBe(5);
+    expect(parseDurationToSec("2 m")).toBe(120);
+    expect(parseDurationToSec("3")).toBe(3);
+  });
+});
+
+describe("jetbrainsOperatorsToCurlArgv", () => {
+  test("maps timeout tags to curl flags", () => {
+    expect(
+      jetbrainsOperatorsToCurlArgv([
+        op("timeout", "10 ms"),
+        op("connection-timeout", "500 ms"),
+      ]),
+    ).toEqual(["--max-time", "0.01", "--connect-timeout", "0.5"]);
+  });
+});
+
+describe("getEffectiveCurlArgv", () => {
+  test("# @timeout overrides env default --max-time", () => {
+    const dir = envDirWithDefaults(["--max-time 2"]);
+    const b = block([op("timeout", "10 ms")]);
+    expect(getEffectiveCurlArgv(undefined, b, "default", dir)).toEqual([
+      "--max-time",
+      "0.01",
+    ]);
+  });
+
+  test("# @connection-timeout overrides env default --connect-timeout", () => {
+    const dir = envDirWithDefaults(["--connect-timeout 5"]);
+    const b = block([op("connection-timeout", "500 ms")]);
+    expect(getEffectiveCurlArgv(undefined, b, "default", dir)).toEqual([
+      "--connect-timeout",
+      "0.5",
+    ]);
+  });
+
+  test("# @kulala-curl--max-time overrides env default", () => {
+    const dir = envDirWithDefaults(["--max-time 2"]);
+    const b = block([op("kulala-curl--max-time", "5")]);
+    expect(getEffectiveCurlArgv(undefined, b, "default", dir)).toEqual([
+      "--max-time",
+      "5",
+    ]);
+  });
+
+  test("passthrough curl operator wins over # @timeout on same flag", () => {
+    const dir = envDirWithDefaults(["--max-time 2"]);
+    const b = block([op("timeout", "10 ms"), op("kulala-curl--max-time", "5")]);
+    expect(getEffectiveCurlArgv(undefined, b, "default", dir)).toEqual([
+      "--max-time",
+      "5",
+    ]);
+  });
+
+  test("block operator overrides file-header operator", () => {
+    const dir = envDirWithDefaults(["--max-time 2"]);
+    const doc = {
+      fileHeaderOperators: [op("timeout", "1 s")],
+    } as KulalaDocument;
+    const b = block([op("timeout", "50 ms")]);
+    expect(getEffectiveCurlArgv(doc, b, "default", dir)).toEqual([
+      "--max-time",
+      "0.05",
+    ]);
+  });
+});
 
 describe("getEffectiveJqFilter", () => {
   test("block operator overrides file header", () => {

--- a/packages/core/src/lib/runner/effective-operators.ts
+++ b/packages/core/src/lib/runner/effective-operators.ts
@@ -6,6 +6,52 @@ import { loadDefaultCurlOptions } from "../variables/default-curl-options";
 
 const JQ_OPERATOR_NAMES = ["kulala-jq", "jq"] as const;
 
+/** JetBrains `# @timeout` / `# @connection-timeout` duration → seconds for curl. */
+export function parseDurationToSec(raw: string): number | undefined {
+  const s = raw.trim();
+  if (!s) return undefined;
+  const m = s.match(/^(\d+(?:\.\d+)?)\s*(ms|s|m)?$/i);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n) || n < 0) return undefined;
+  const unit = (m[2] ?? "s").toLowerCase();
+  if (unit === "ms") return n / 1000;
+  if (unit === "m") return n * 60;
+  return n;
+}
+
+function getOperatorArgs(
+  operators: KulalaOperator[],
+  names: string[],
+): string | undefined {
+  for (const op of operators) {
+    if (!names.includes(op.name)) continue;
+    const args = String(op.args ?? "").trim();
+    if (args) return args;
+  }
+  return undefined;
+}
+
+/** JetBrains timeout tags → curl `--max-time` / `--connect-timeout`. */
+export function jetbrainsOperatorsToCurlArgv(
+  operators: KulalaOperator[],
+): string[] {
+  const argv: string[] = [];
+  const timeoutSec = parseDurationToSec(
+    getOperatorArgs(operators, ["timeout"]) ?? "",
+  );
+  if (timeoutSec !== undefined) {
+    argv.push("--max-time", String(Math.max(0, timeoutSec)));
+  }
+  const connectionTimeoutSec = parseDurationToSec(
+    getOperatorArgs(operators, ["connection-timeout"]) ?? "",
+  );
+  if (connectionTimeoutSec !== undefined) {
+    argv.push("--connect-timeout", String(Math.max(0, connectionTimeoutSec)));
+  }
+  return argv;
+}
+
 /**
  * File-header operators merged with block operators; block wins on same operator name.
  */
@@ -54,7 +100,9 @@ export function getEffectiveCurlArgv(
   env: string,
   startDir: string,
 ): string[] {
+  const operators = getEffectiveOperators(doc, block);
   const envArgv = loadDefaultCurlOptions(env, startDir);
-  const operatorArgv = curlArgvFromOperators(getEffectiveOperators(doc, block));
-  return mergeCurlArgv([envArgv, operatorArgv]);
+  const jetbrainsArgv = jetbrainsOperatorsToCurlArgv(operators);
+  const passthroughArgv = curlArgvFromOperators(operators);
+  return mergeCurlArgv([envArgv, jetbrainsArgv, passthroughArgv]);
 }


### PR DESCRIPTION
Fix curl settings in http-client* having precedence over request operators.

Also add load-test examples.