### PR TITLE
fix(lsp): clear and clearAll are children of client.global

### DIFF
--- a/packages/core/src/lib/lsp/script-api-docs.ts
+++ b/packages/core/src/lib/lsp/script-api-docs.ts
@@ -106,15 +106,15 @@ export const SCRIPT_API_DOCS: Record<string, ScriptApiDoc> = {
     signature: "client.isEmpty(): boolean",
     example: "if (client.isEmpty()) client.log('No globals');",
   },
-  "client.clear": {
+  "client.global.clear": {
     summary: "Remove a single variable from global storage.",
-    signature: "client.clear(varName: string)",
-    example: 'client.clear("SOME_TOKEN");',
+    signature: "client.global.clear(varName: string)",
+    example: 'client.global.clear("SOME_TOKEN");',
   },
-  "client.clearAll": {
+  "client.global.clearAll": {
     summary: "Remove all global variables.",
-    signature: "client.clearAll()",
-    example: "client.clearAll();",
+    signature: "client.global.clearAll()",
+    example: "client.global.clearAll();",
   },
   "client.exit": {
     summary: "Stop executing the current response handler script.",

--- a/packages/core/src/lib/lsp/sources.ts
+++ b/packages/core/src/lib/lsp/sources.ts
@@ -129,7 +129,7 @@ export function staticCompletionItems(sourceName: string): LspCompletionItem[] {
     },
     {
       label: "timeout",
-      insertText: "timeout 5s",
+      insertText: "timeout 500 ms",
       documentation: "Total request timeout (500 ms, 5 s)",
     },
     {
@@ -344,13 +344,13 @@ export function staticCompletionItems(sourceName: string): LspCompletionItem[] {
       documentation: "Check if globals are empty",
     },
     {
-      label: "client.clear",
-      insertText: 'client.clear(${1:"varName"})$0',
+      label: "client.global.clear",
+      insertText: 'client.global.clear(${1:"varName"})$0',
       documentation: "Clear a global variable",
     },
     {
-      label: "client.clearAll",
-      insertText: "client.clearAll()$0",
+      label: "client.global.clearAll",
+      insertText: "client.global.clearAll()$0",
       documentation: "Clear all global variables",
     },
     {


### PR DESCRIPTION
Previously, the LSP suggested you to use client.clear and client.clearAll, but they are actually children of client.global. This commit fixes the documentation to reflect that.