### PR TITLE
feat(runner): add $kulala.request.abort()

### DIFF
--- a/http-example-files/openapi-port.impersonate.http.js
+++ b/http-example-files/openapi-port.impersonate.http.js
@@ -1,4 +1,18 @@
+if (request.url.tryGetSubstituted().endsWith("/swagger/json")) {
+  client.exit(0);
+  return;
+}
+
 const { spawnSync } = require("node:child_process");
+
+const whichPort = spawnSync("which", ["port"], {
+  encoding: "utf-8",
+});
+if (whichPort.status !== 0) {
+  client.log("Port CLI is not installed. Please install it to continue.");
+  $kulala.request.abort();
+  return;
+}
 
 const isExcludedURL = (url) => {
   if (!url) return true;
@@ -40,14 +54,13 @@ if (PORT_BEARER_TOKEN) {
 }
 
 // We need to get a new token
-
 RES = spawnSync("port", ["auth", "token"], {
   encoding: "utf-8",
 });
 
 if (RES.error) {
   client.log(RES.error);
-  client.exit();
+  $kulala.request.abort();
   return;
 }
 

--- a/packages/core/src/lib/lsp/lsp.test.ts
+++ b/packages/core/src/lib/lsp/lsp.test.ts
@@ -399,6 +399,7 @@ test("lspCompletion includes $kulala API items with documentation", async () => 
   const labels = new Set(res.items.map((i) => i.label));
   expect(labels.has("$kulala.prompt")).toBe(true);
   expect(labels.has("$kulala.request.skip")).toBe(true);
+  expect(labels.has("$kulala.request.abort")).toBe(true);
   expect(labels.has("$kulala.runRequest")).toBe(true);
   expect(labels.has("$kulala.client.global.headers.set")).toBe(true);
   const item = res.items.find((i) => i.label === "$kulala.prompt");

--- a/packages/core/src/lib/lsp/script-api-docs.ts
+++ b/packages/core/src/lib/lsp/script-api-docs.ts
@@ -36,7 +36,16 @@ export const SCRIPT_API_DOCS: Record<string, ScriptApiDoc> = {
   "$kulala.request.skip": {
     summary: "Skip sending the current request. Pre-request scripts only.",
     signature: "$kulala.request.skip()",
-    notes: 'In Lua: `_G["$kulala"].request.skip()`.',
+    notes:
+      'In Lua: `_G["$kulala"].request.skip()`. Soft skip: success continues the document.',
+  },
+  "$kulala.request.abort": {
+    summary:
+      "Abort sending the current request as a failure. Pre-request scripts only.",
+    signature: "$kulala.request.abort(message?: string)",
+    example: '$kulala.request.abort("missing token");',
+    notes:
+      'In Lua: `_G["$kulala"].request.abort()`. Unlike skip, this is an error (respects haltOnError).',
   },
   "$kulala.request.replay": {
     summary:
@@ -167,6 +176,28 @@ export const SCRIPT_API_DOCS: Record<string, ScriptApiDoc> = {
   "request.url.tryGetSubstituted": {
     summary: "Request URL with variables substituted.",
     signature: "request.url.tryGetSubstituted(): string",
+  },
+  "request.skip": {
+    summary: "Skip sending the current request. Pre-request scripts only.",
+    signature: "request.skip()",
+    example: "request.skip();",
+    notes:
+      "Alias of `$kulala.request.skip()`. Soft skip: success continues the document.",
+  },
+  "request.abort": {
+    summary:
+      "Abort sending the current request as a failure. Pre-request scripts only.",
+    signature: "request.abort(message?: string)",
+    example: 'request.abort("missing token");',
+    notes:
+      "Alias of `$kulala.request.abort()`. Unlike skip, this is an error (respects haltOnError).",
+  },
+  "request.replay": {
+    summary:
+      "Re-run the current request (pre- and post-request scripts). Replays are capped per request.",
+    signature: "request.replay()",
+    example: "request.replay();",
+    notes: "Alias of `$kulala.request.replay()`.",
   },
   "response.contentType.mimeType": {
     summary: "Content-Type of the response, if any.",

--- a/packages/core/src/lib/lsp/sources.ts
+++ b/packages/core/src/lib/lsp/sources.ts
@@ -299,6 +299,11 @@ export function staticCompletionItems(sourceName: string): LspCompletionItem[] {
       documentation: "Skip sending this request (pre-request only)",
     },
     {
+      label: "$kulala.request.abort",
+      insertText: "$kulala.request.abort(${1:message})$0",
+      documentation: "Abort this request as an error (pre-request only)",
+    },
+    {
       label: "$kulala.request.replay",
       insertText: "$kulala.request.replay()$0",
       documentation: "Re-run the current request",
@@ -424,6 +429,21 @@ export function staticCompletionItems(sourceName: string): LspCompletionItem[] {
       label: "request.url.tryGetSubstituted",
       insertText: "request.url.tryGetSubstituted()$0",
       documentation: "Get substituted request URL",
+    },
+    {
+      label: "request.skip",
+      insertText: "request.skip()$0",
+      documentation: "Skip sending this request (pre-request only)",
+    },
+    {
+      label: "request.abort",
+      insertText: "request.abort(${1:message})$0",
+      documentation: "Abort this request as an error (pre-request only)",
+    },
+    {
+      label: "request.replay",
+      insertText: "request.replay()$0",
+      documentation: "Re-run the current request",
     },
     {
       label: "request.iteration",

--- a/packages/core/src/lib/runner/doRequest.test.ts
+++ b/packages/core/src/lib/runner/doRequest.test.ts
@@ -504,6 +504,128 @@ test("doRequestFromBlock: $kulala.request.skip in pre-script skips HTTP", async 
   expect(result).toHaveProperty("skipped", true);
 });
 
+test("doRequestFromBlock: client.log before skip is preserved in scriptConsole", async () => {
+  const block = makeBlock({
+    scripts: {
+      preRequest: [
+        {
+          type: "preRequest",
+          source: "inline",
+          lang: "js",
+          content: `
+            client.log("before skip");
+            $kulala.request.skip();
+          `,
+          lineNumber: 1,
+        },
+      ],
+      postRequest: [],
+    },
+  });
+
+  const result = await doRequestFromBlock(
+    block,
+    "/tmp/example.http",
+    undefined,
+    "stable-doc",
+    undefined,
+    "default",
+    { globalHeaders: {} },
+  );
+
+  expect(result).toHaveProperty("success", true);
+  expect(result).toHaveProperty("skipped", true);
+  expect(result).toHaveProperty("scriptConsole");
+  if ("scriptConsole" in result && Array.isArray(result.scriptConsole)) {
+    expect(result.scriptConsole.some((l) => l.message === "before skip")).toBe(
+      true,
+    );
+  }
+  if ("body" in result && result.body && result.body.type === "text") {
+    expect(result.body.content).toContain("before skip");
+    expect(result.body.content).toContain("Request skipped by script");
+  } else {
+    throw new Error("expected skip body with script logs");
+  }
+});
+
+test("doRequestFromBlock: $kulala.request.abort in pre-script fails without HTTP", async () => {
+  const block = makeBlock({
+    scripts: {
+      preRequest: [
+        {
+          type: "preRequest",
+          source: "inline",
+          lang: "js",
+          content: `
+            client.log("before abort");
+            $kulala.request.abort("missing token");
+          `,
+          lineNumber: 1,
+        },
+      ],
+      postRequest: [],
+    },
+  });
+
+  const result = await doRequestFromBlock(
+    block,
+    "/tmp/example.http",
+    undefined,
+    "stable-doc",
+    undefined,
+    "default",
+    { globalHeaders: {} },
+  );
+
+  expect(result).toHaveProperty("success", false);
+  expect(result).toHaveProperty("aborted", true);
+  expect(result).toHaveProperty("error", "missing token");
+  expect(result).not.toHaveProperty("httpCompleted", true);
+  if ("scriptConsole" in result && Array.isArray(result.scriptConsole)) {
+    expect(result.scriptConsole.some((l) => l.message === "before abort")).toBe(
+      true,
+    );
+  }
+  if ("body" in result && result.body && result.body.type === "text") {
+    expect(result.body.content).toContain("before abort");
+    expect(result.body.content).toContain("missing token");
+  } else {
+    throw new Error("expected abort body with script logs");
+  }
+});
+
+test("doRequestFromBlock: request.abort alias aborts without HTTP", async () => {
+  const block = makeBlock({
+    scripts: {
+      preRequest: [
+        {
+          type: "preRequest",
+          source: "inline",
+          lang: "js",
+          content: `request.abort();`,
+          lineNumber: 1,
+        },
+      ],
+      postRequest: [],
+    },
+  });
+
+  const result = await doRequestFromBlock(
+    block,
+    "/tmp/example.http",
+    undefined,
+    "stable-doc",
+    undefined,
+    "default",
+    { globalHeaders: {} },
+  );
+
+  expect(result).toHaveProperty("success", false);
+  expect(result).toHaveProperty("aborted", true);
+  expect(result).toHaveProperty("error", "Request aborted by script");
+});
+
 test("doRequestFromBlock: $kulala.request.replay in pre-script re-runs with updated vars", async () => {
   const block = makeBlock({
     scripts: {

--- a/packages/core/src/lib/runner/doRequest.ts
+++ b/packages/core/src/lib/runner/doRequest.ts
@@ -42,6 +42,7 @@ import {
 import { ScriptPromptError } from "./script-prompt-error";
 import {
   MAX_SCRIPT_REPLAYS,
+  ScriptAbortError,
   ScriptReplayError,
   ScriptSkipError,
 } from "./script-control-error";
@@ -115,6 +116,23 @@ export type DoRequestFromBlockResult =
   | KulalaWebSocketPlanResponse;
 
 const CLIENT_GLOBAL_HEADERS_VAR = "__kulala_client_global_headers__";
+
+function scriptConsolePlainText(lines: KulalaScriptConsoleLine[]): string {
+  return lines
+    .map((l) => (typeof l.message === "string" ? l.message : String(l.message)))
+    .filter((m) => m.trim().length > 0)
+    .join("\n");
+}
+
+/** Visible body for skip/abort so clients with a body-first UI show pre-exit logs. */
+function controlFlowBody(
+  scriptConsole: KulalaScriptConsoleLine[],
+  footer: string,
+): KulalaRequestSuccessResponse["body"] {
+  const logs = scriptConsolePlainText(scriptConsole);
+  const content = logs.length > 0 ? `${logs}\n\n${footer}` : footer;
+  return { type: "text", content, mediaType: "text/plain" };
+}
 
 function readClientGlobalHeaders(): Record<string, string> {
   const v = getVariable("global", CLIENT_GLOBAL_HEADERS_VAR);
@@ -538,8 +556,18 @@ export async function doRequestFromBlock(
           return {
             success: true,
             skipped: true,
+            body: controlFlowBody(scriptConsole, "Request skipped by script"),
             ...(scriptConsole.length > 0 ? { scriptConsole } : {}),
           } as KulalaSkippedResponse;
+        }
+        if (error instanceof ScriptAbortError) {
+          return {
+            success: false,
+            aborted: true,
+            error: error.message,
+            body: controlFlowBody(scriptConsole, error.message),
+            ...(scriptConsole.length > 0 ? { scriptConsole } : {}),
+          } as KulalaRequestErrorResponse;
         }
         if (error instanceof ScriptReplayError) {
           scriptReplayIndex += 1;

--- a/packages/core/src/lib/runner/kulala-script-api.ts
+++ b/packages/core/src/lib/runner/kulala-script-api.ts
@@ -6,7 +6,11 @@ import {
 } from "./custom-prompt";
 import { getVariable, setVariable } from "../persistence";
 import { ScriptPromptError } from "./script-prompt-error";
-import { ScriptReplayError, ScriptSkipError } from "./script-control-error";
+import {
+  ScriptAbortError,
+  ScriptReplayError,
+  ScriptSkipError,
+} from "./script-control-error";
 import type { ScriptFlowContext } from "./scripts";
 import type { ScriptResponse } from "./script-response";
 import type { VariableResolver } from "./types";
@@ -59,6 +63,8 @@ export type KulalaScriptApi = {
   request: {
     /** Skip sending this request (pre-request scripts only). */
     skip: () => void;
+    /** Abort sending this request as a failure (pre-request scripts only). */
+    abort: (message?: string) => void;
     /** Re-run this request from pre-request scripts (pre- and post-request). */
     replay: () => void;
   };
@@ -146,6 +152,14 @@ export function buildKulalaScriptApi(ctx: {
           );
         }
         throw new ScriptSkipError();
+      },
+      abort(message?: string) {
+        if (ctx.phase !== "preRequest") {
+          throw new Error(
+            "$kulala.request.abort() is only available in pre-request scripts",
+          );
+        }
+        throw new ScriptAbortError(message);
       },
       replay() {
         throw new ScriptReplayError();

--- a/packages/core/src/lib/runner/resolve-request-from-block.ts
+++ b/packages/core/src/lib/runner/resolve-request-from-block.ts
@@ -11,6 +11,7 @@ import { ScriptPromptError } from "./script-prompt-error";
 import { getVariable } from "../persistence";
 import {
   MAX_SCRIPT_REPLAYS,
+  ScriptAbortError,
   ScriptReplayError,
   ScriptSkipError,
 } from "./script-control-error";
@@ -214,6 +215,9 @@ export async function resolveRequestFromBlock(
       }
       if (error instanceof ScriptSkipError) {
         return { ok: false, skipped: true };
+      }
+      if (error instanceof ScriptAbortError) {
+        return { ok: false, error: error.message };
       }
       if (error instanceof ScriptReplayError) {
         scriptReplayIndex += 1;

--- a/packages/core/src/lib/runner/script-control-error.ts
+++ b/packages/core/src/lib/runner/script-control-error.ts
@@ -6,6 +6,18 @@ export class ScriptSkipError extends Error {
   }
 }
 
+/** Pre-request script asked to abort sending this request (failure, not soft skip). */
+export class ScriptAbortError extends Error {
+  override name = "ScriptAbortError";
+  constructor(message?: string) {
+    super(
+      typeof message === "string" && message.trim().length > 0
+        ? message
+        : "Request aborted by script",
+    );
+  }
+}
+
 /** Script asked to re-run this request (JetBrains `request.replay()`). */
 export class ScriptReplayError extends Error {
   override name = "ScriptReplayError";

--- a/packages/core/src/lib/runner/script-request-context.ts
+++ b/packages/core/src/lib/runner/script-request-context.ts
@@ -5,6 +5,11 @@ import {
   parseStoredVariable,
   writeVariableToMaps,
 } from "../variables/variable-lookup";
+import {
+  ScriptAbortError,
+  ScriptReplayError,
+  ScriptSkipError,
+} from "./script-control-error";
 import type { VariableResolver } from "./types";
 import { buildHeadersFromSection } from "./headers";
 import { normalizeSetCookieFromLine } from "../persistence/cookie-store";
@@ -116,6 +121,12 @@ type ScriptVariablesApi = {
   all: () => Record<string, string>;
 };
 
+type ScriptRequestControlApi = {
+  skip: () => never;
+  abort: (message?: string) => never;
+  replay: () => never;
+};
+
 export type PreRequestScriptApi = {
   variables: ScriptVariablesApi;
   environment: { get: (name: string) => string | null };
@@ -134,7 +145,7 @@ export type PreRequestScriptApi = {
     getRaw: () => string;
     tryGetSubstituted: () => string;
   };
-};
+} & ScriptRequestControlApi;
 
 export type PostRequestScriptApi = {
   variables: ScriptVariablesApi;
@@ -148,7 +159,7 @@ export type PostRequestScriptApi = {
   };
   body: () => string | undefined;
   url: () => string;
-};
+} & ScriptRequestControlApi;
 
 function makePreRequestHeader(
   name: string,
@@ -170,12 +181,39 @@ function makePostRequestHeader(name: string, value: string): PostRequestHeader {
   };
 }
 
+function makeRequestControlApi(
+  phase: "preRequest" | "postRequest",
+): ScriptRequestControlApi {
+  return {
+    skip() {
+      if (phase !== "preRequest") {
+        throw new Error(
+          "request.skip() is only available in pre-request scripts",
+        );
+      }
+      throw new ScriptSkipError();
+    },
+    abort(message?: string) {
+      if (phase !== "preRequest") {
+        throw new Error(
+          "request.abort() is only available in pre-request scripts",
+        );
+      }
+      throw new ScriptAbortError(message);
+    },
+    replay() {
+      throw new ScriptReplayError();
+    },
+  };
+}
+
 export type ScriptRequestApi = PreRequestScriptApi | PostRequestScriptApi;
 
 export function buildScriptRequestApi(
   ctx: ScriptRequestContext,
 ): ScriptRequestApi {
   const envVars = loadEnvVars(ctx.env, ctx.startDir);
+  const control = makeRequestControlApi(ctx.phase);
 
   const variables = {
     set: (name: string, value: unknown) => {
@@ -245,6 +283,7 @@ export function buildScriptRequestApi(
           ctx.urlSubstituted ??
           substituteInString(ctx.urlRaw, ctx.mutableVars, ctx.resolver),
       },
+      ...control,
     };
   }
 
@@ -272,6 +311,7 @@ export function buildScriptRequestApi(
     },
     body: () => ctx.bodySent,
     url: () => ctx.urlSent ?? "",
+    ...control,
   };
 }
 

--- a/packages/core/src/lib/runner/scripts.test.ts
+++ b/packages/core/src/lib/runner/scripts.test.ts
@@ -5,7 +5,11 @@ import { join } from "path";
 import { runScripts } from "./scripts";
 import { getDbInMemory, getVariable, setDbForTesting } from "../persistence";
 import { ScriptPromptError } from "./script-prompt-error";
-import { ScriptReplayError, ScriptSkipError } from "./script-control-error";
+import {
+  ScriptAbortError,
+  ScriptReplayError,
+  ScriptSkipError,
+} from "./script-control-error";
 import type { KulalaBlock } from "../parser/types/block";
 import type { KulalaHttpURL } from "../parser/types/request";
 
@@ -719,6 +723,59 @@ client.global.set("DATE", response.headers.valueOf("Date") || "");`,
     }
   });
 
+  test("$kulala.request.abort throws ScriptAbortError in pre-request", async () => {
+    try {
+      await runScripts(
+        [
+          {
+            type: "preRequest",
+            source: "inline",
+            lang: "js",
+            content: `$kulala.request.abort("missing token");`,
+            lineNumber: 1,
+          },
+        ],
+        "preRequest",
+        dummyBlock,
+        "/tmp/example.http",
+        undefined,
+        {},
+        undefined,
+        undefined,
+        undefined,
+        { stableDocId: "stable-doc" },
+      );
+      throw new Error("expected ScriptAbortError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ScriptAbortError);
+      expect((e as Error).message).toBe("missing token");
+    }
+  });
+
+  test("request.skip throws ScriptSkipError in pre-request", async () => {
+    try {
+      await runScripts(
+        [
+          {
+            type: "preRequest",
+            source: "inline",
+            lang: "js",
+            content: `request.skip();`,
+            lineNumber: 1,
+          },
+        ],
+        "preRequest",
+        dummyBlock,
+        "/tmp/example.http",
+        undefined,
+        {},
+      );
+      throw new Error("expected ScriptSkipError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ScriptSkipError);
+    }
+  });
+
   test("$kulala.request.replay throws ScriptReplayError", async () => {
     try {
       await runScripts(
@@ -752,6 +809,32 @@ client.global.set("DATE", response.headers.valueOf("Date") || "");`,
             source: "inline",
             lang: "js",
             content: `$kulala.request.skip();`,
+            lineNumber: 1,
+          },
+        ],
+        "postRequest",
+        dummyBlock,
+        "/tmp/example.http",
+        {
+          statusCode: 200,
+          headers: {},
+          body: "",
+          timings: { phases: { total: 1 } },
+        },
+        {},
+      ),
+    ).rejects.toThrow(/pre-request/);
+  });
+
+  test("$kulala.request.abort is not available in post-request scripts", async () => {
+    await expect(
+      runScripts(
+        [
+          {
+            type: "postRequest",
+            source: "inline",
+            lang: "js",
+            content: `$kulala.request.abort();`,
             lineNumber: 1,
           },
         ],

--- a/packages/core/src/lib/runner/scripts.ts
+++ b/packages/core/src/lib/runner/scripts.ts
@@ -41,7 +41,11 @@ import {
 } from "./script-request-context";
 import { buildKulalaScriptApi } from "./kulala-script-api";
 import { ScriptPromptError } from "./script-prompt-error";
-import { ScriptReplayError, ScriptSkipError } from "./script-control-error";
+import {
+  ScriptAbortError,
+  ScriptReplayError,
+  ScriptSkipError,
+} from "./script-control-error";
 import { makeResponseForScripts, type ScriptResponse } from "./script-response";
 
 export type { ScriptContentType } from "./script-response";
@@ -541,6 +545,9 @@ async function executeLuaScript(
       all: () => req.headers.all(),
       findByName: (name: string) => req.headers.findByName(name),
     },
+    skip: () => req.skip(),
+    abort: (message?: string) => req.abort(message),
+    replay: () => req.replay(),
   };
   luaCtx.response = {
     status: ctx.response.status,
@@ -892,6 +899,7 @@ export const runScripts = async (
       if (
         error instanceof ScriptPromptError ||
         error instanceof ScriptSkipError ||
+        error instanceof ScriptAbortError ||
         error instanceof ScriptReplayError
       ) {
         throw error;

--- a/packages/core/src/lib/runner/types.ts
+++ b/packages/core/src/lib/runner/types.ts
@@ -143,6 +143,8 @@ export type KulalaRequestErrorResponse = {
   error: string;
   /** Present when scripts ran before the failure (e.g. pre-request or failed expect-status). */
   scriptConsole?: KulalaScriptConsoleLine[];
+  /** Pre-request script called `$kulala.request.abort()` - no HTTP request was sent. */
+  aborted?: true;
   /**
    * HTTP finished before the failure (JetBrains: response-handler script errors).
    * Response fields below are populated so the UI can still show the received response.
@@ -181,6 +183,8 @@ export type KulalaSkippedResponse = {
   skipped: true;
   blockName?: string;
   scriptConsole?: KulalaScriptConsoleLine[];
+  /** Synthetic body so UIs that default to the body pane still show pre-skip logs. */
+  body: KulalaRequestSuccessResponse["body"];
 };
 
 export type KulalaResponseWrapper =


### PR DESCRIPTION
also fix $kulala.request.skip() to now swallow client.logs